### PR TITLE
Allows upload to receive multiple file names

### DIFF
--- a/exe/appmap
+++ b/exe/appmap
@@ -102,16 +102,21 @@ module AppMap
 
       c.action do |_, options, args|
         require 'appmap/command/upload'
-        filename = args.shift or help_now!("'filename' argument is required")
-        appmap = JSON.parse(File.read(filename))
 
-        url = options[:url]
-        owner = options[:owner]
+        filenames = args
+        help_now!("'filename' argument is required") if filenames.empty?
 
-        scenario_uuid = AppMap::Command::Upload.new(@config, appmap, url, owner).perform
-        $stderr.write 'Uploaded new scenario: '
-        @output_file.puts scenario_uuid
-        system "open #{url}/scenarios/#{scenario_uuid}" if options[:open]
+        filenames.each do |filename|
+          appmap = JSON.parse(File.read(filename))
+
+          url = options[:url]
+          owner = options[:owner]
+
+          scenario_uuid = AppMap::Command::Upload.new(@config, appmap, url, owner).perform
+          $stderr.write 'Uploaded new scenario: '
+          @output_file.puts scenario_uuid
+          system "open #{url}/scenarios/#{scenario_uuid}" if options[:open]
+        end
       end
     end
 

--- a/exe/appmap
+++ b/exe/appmap
@@ -106,17 +106,30 @@ module AppMap
         filenames = args
         help_now!("'filename' argument is required") if filenames.empty?
 
-        filenames.each do |filename|
+        url = options[:url]
+        owner = options[:owner]
+
+        uuids = filenames.map do |filename|
           appmap = JSON.parse(File.read(filename))
 
-          url = options[:url]
-          owner = options[:owner]
-
-          scenario_uuid = AppMap::Command::Upload.new(@config, appmap, url, owner).perform
-          $stderr.write 'Uploaded new scenario: '
-          @output_file.puts scenario_uuid
-          system "open #{url}/scenarios/#{scenario_uuid}" if options[:open]
+          AppMap::Command::Upload.new(@config, appmap, url, owner).perform.tap do |uuid|
+            $stderr.write 'Uploaded new scenario: '
+            @output_file.puts uuid
+          end
         end
+
+        confirm_launch = lambda do
+          return false if filenames.empty?
+
+          return true if filenames.size == 1
+
+          warn "Open browser windows for #{filenames.size} AppMap files? (y/n)"
+          return %w[y yes].include?(STDIN.gets.strip)
+        end
+
+        open_uuid = ->(uuid) { system "open #{url}/scenarios/#{uuid}" }
+
+        uuids.each(&open_uuid) if STDIN.tty? && confirm_launch.call
       end
     end
 


### PR DESCRIPTION
This allows users to leverage shell expansion such as filename globbing to
easily load multiple files at once.

For example:
```
$ appmap upload ~/tmp/appmap/rspec/*
Full classMap contains 39 classes
Pruned classMap contains 8 classes
Uploaded new scenario: ddf307a0-d0b2-47ea-bc37-14a1198a1973
Full classMap contains 39 classes
Pruned classMap contains 8 classes
Uploaded new scenario: ca716315-36f1-48f9-b9a9-df2d7f208ad0
Full classMap contains 39 classes
Pruned classMap contains 8 classes
Uploaded new scenario: fcbc27d7-c73d-43c7-b5ce-dc19932fd7dc
```