### PR TITLE
Add language and frameworks to AppMap metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.11.0
+
+* Information about `language` and `frameworks` is provided in the AppMap `metadata`.
+
 # v0.10.0
 
 * **`AppMap::Algorithm::PruneClassMap`** prunes a class map so that only functions, classes and packages which are

--- a/exe/appmap
+++ b/exe/appmap
@@ -77,7 +77,9 @@ module AppMap
 
         require 'appmap/command/record'
         AppMap::Command::Record.new(@config, program).perform do |features, events|
-          @output_file.write JSON.generate(classMap: features, events: events)
+          @output_file.write JSON.generate(classMap: features,
+                                           metadata: AppMap::Command::Record.detect_metadata,
+                                           events: events)
         end
       end
     end

--- a/lib/appmap/command/record.rb
+++ b/lib/appmap/command/record.rb
@@ -3,6 +3,59 @@ module AppMap
     RecordStruct = Struct.new(:config, :program)
 
     class Record < RecordStruct
+      class << self
+        # Builds a Hash of metadata which can be detected by inspecting the system.
+        def detect_metadata
+          {
+            language: {
+              name: 'ruby',
+              engine: RUBY_ENGINE,
+              version: RUBY_VERSION
+            }
+          }.tap do |m|
+            if defined?(::Rails)
+              m[:frameworks] ||= []
+              m[:frameworks] << {
+                name: 'rails',
+                version: ::Rails.version
+              }
+              m[:layout] = 'rails'
+            end
+            m[:git] = git_metadata if git_available
+          end
+        end
+
+        protected
+
+        def git_available
+          @git_available = system('git status 2>&1 > /dev/null') if @git_available.nil?
+        end
+
+        def git_metadata
+          git_repo = `git config --get remote.origin.url`.strip
+          git_branch = `git rev-parse --abbrev-ref HEAD`.strip
+          git_sha = `git rev-parse HEAD`.strip
+          git_status = `git status -s`.split("\n").map(&:strip)
+          git_last_annotated_tag = `git describe --abbrev=0 2>/dev/null`.strip
+          git_last_annotated_tag = nil if git_last_annotated_tag.blank?
+          git_last_tag = `git describe --abbrev=0 --tags 2>/dev/null`.strip
+          git_last_tag = nil if git_last_tag.blank?
+          git_commits_since_last_annotated_tag = `git describe`.strip =~ /-(\d+)-(\w+)$/[1] rescue 0 if git_last_annotated_tag
+          git_commits_since_last_tag = `git describe --tags`.strip =~ /-(\d+)-(\w+)$/[1] rescue 0 if git_last_tag
+
+          {
+            repository: git_repo,
+            branch: git_branch,
+            commit: git_sha,
+            status: git_status,
+            git_last_annotated_tag: git_last_annotated_tag,
+            git_last_tag: git_last_tag,
+            git_commits_since_last_annotated_tag: git_commits_since_last_annotated_tag,
+            git_commits_since_last_tag: git_commits_since_last_tag
+          }
+        end
+      end
+
       def perform(&block)
         features = AppMap.inspect(config)
         functions = features.map(&:collect_functions).flatten

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AppMap
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end


### PR DESCRIPTION
Added a `detect_metadata` function which will automatically add `language` and `frameworks` to the scenario metadata.

Any code which is writing a scenario should call `detect_metadata` to get the base metadata, then add any other specific metadata (e.g. additional frameworks).