### PR TITLE
Record button position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.15.1
+
+* **Record button** moved to the bottom of the window.
+
 # v0.15.0
 
 **WARNING** Breaking changes
@@ -20,7 +24,7 @@
 
 # v0.12.0
 
-* **Record Button** integrates into any HTML UI and provides a button to record and upload AppMaps.
+* **Record button** integrates into any HTML UI and provides a button to record and upload AppMaps.
 
 # v0.11.0
 

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AppMap
-  VERSION = '0.15.0'
+  VERSION = '0.15.1'
 end

--- a/public/appmap.css
+++ b/public/appmap.css
@@ -1,6 +1,6 @@
 #appmap-record-container {
   position: fixed;
-  top: 0em;
+  bottom: 0em;
   left: 0em;
   width: 8em;
   height: 2em;


### PR DESCRIPTION
Moving the record button to the bottom of the window so that users can scroll away from it and it doesn't cover branding and search by default.