### PR TITLE
Scenario metadata "recorder" and "client" fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.21.0
 
-* Scenario data includes `recorder` info, describing how the data was recorded.
+* Scenario data includes `recorder` and `client` info, describing how the data was recorded.
 
 # v0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.21.0
+
+* Scenario data includes `recorder` info, describing how the data was recorded.
+
 # v0.20.0
 
 Updated to [AppMap file format](https://github.com/applandinc/appmap) version 1.2.

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
@@ -9,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Kevin Gilpin']
   spec.email         = ['kgilpin@gmail.com']
 
-  spec.summary       = %q{Inspect and trace your Ruby code, generating a JSON data file.}
-  spec.homepage      = 'https://github.com/kgilpin/appmap-ruby'
+  spec.summary       = %q{Record the operation of a Ruby program, using the AppLand 'AppMap' format.}
+  spec.homepage      = AppMap::URL
   spec.license       = 'MIT'
 
   # Specify which files should be added to the gem when it is released.

--- a/lib/appmap/command/record.rb
+++ b/lib/appmap/command/record.rb
@@ -11,6 +11,11 @@ module AppMap
               name: 'ruby',
               engine: RUBY_ENGINE,
               version: RUBY_VERSION
+            },
+            client: {
+              name: 'appmap',
+              url: AppMap::URL,
+              version: AppMap::VERSION
             }
           }.tap do |m|
             if defined?(::Rails)

--- a/lib/appmap/middleware/remote_recording.rb
+++ b/lib/appmap/middleware/remote_recording.rb
@@ -70,8 +70,7 @@ module AppMap
         require 'appmap/command/record'
         metadata = AppMap::Command::Record.detect_metadata
         metadata[:recorder] = {
-          name: 'remote_recording',
-          version: AppMap::VERSION
+          name: 'remote_recording'
         }
 
         response = JSON.generate(version: AppMap::APPMAP_FORMAT_VERSION, classMap: @features, metadata: metadata, events: @events)

--- a/lib/appmap/middleware/remote_recording.rb
+++ b/lib/appmap/middleware/remote_recording.rb
@@ -69,6 +69,10 @@ module AppMap
 
         require 'appmap/command/record'
         metadata = AppMap::Command::Record.detect_metadata
+        metadata[:recorder] = {
+          name: 'remote_recording',
+          version: AppMap::VERSION
+        }
 
         response = JSON.generate(version: AppMap::APPMAP_FORMAT_VERSION, classMap: @features, metadata: metadata, events: @events)
 

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -42,6 +42,10 @@ module AppMap
             name: 'rspec',
             version: Gem.loaded_specs['rspec-core']&.version&.to_s
           }
+          m[:recorder] = {
+            name: 'rspec',
+            version: AppMap::VERSION
+          }
         end
 
         appmap = {

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -43,8 +43,7 @@ module AppMap
             version: Gem.loaded_specs['rspec-core']&.version&.to_s
           }
           m[:recorder] = {
-            name: 'rspec',
-            version: AppMap::VERSION
+            name: 'rspec'
           }
         end
 
@@ -276,14 +275,17 @@ module AppMap
               description = []
               leaf = scope = ScopeExample.new(example)
               feature_group = feature = nil
-              labels = scope.labels.map(&:to_s).map(&:strip).reject(&:blank?).map(&:downcase).uniq
 
+              labels = []
               while scope
+                labels += scope.labels
                 description << scope.description
                 feature ||= scope.feature
                 feature_group ||= scope.feature_group
                 scope = scope.parent
               end
+
+              labels = labels.map(&:to_s).map(&:strip).reject(&:blank?).map(&:downcase).uniq
               description.reject!(&:nil?).reject(&:blank?)
               default_description = description.last
               description.reverse!

--- a/lib/appmap/trace/tracer.rb
+++ b/lib/appmap/trace/tracer.rb
@@ -135,7 +135,7 @@ module AppMap
         end
 
         def collect_parameters(tp)
-          tp.self.method(tp.method_id).parameters.collect do |pinfo|
+          -> { tp.self.method(tp.method_id).parameters rescue [] }.call.collect do |pinfo|
             kind, key = pinfo
             value = value_in_binding(tp, key)
             {

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AppMap
-  VERSION = '0.20.0'
+  VERSION = '0.21.0'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module AppMap
+  URL = 'https://github.com/applandinc/appmap-ruby'
+
   VERSION = '0.21.0'
 
   APPMAP_FORMAT_VERSION = '1.2'

--- a/test/fixtures/rspec_recorder/spec/decorated_hello_spec.rb
+++ b/test/fixtures/rspec_recorder/spec/decorated_hello_spec.rb
@@ -1,0 +1,9 @@
+require 'rspec'
+require 'appmap/rspec'
+require 'hello'
+
+describe Hello, feature_group: 'Saying hello' do
+  it 'says hello', feature: 'Speak hello', appmap: true do
+    expect(Hello.new.say_hello).to eq('Hello!')
+  end
+end

--- a/test/fixtures/rspec_recorder/spec/labeled_hello_spec.rb
+++ b/test/fixtures/rspec_recorder/spec/labeled_hello_spec.rb
@@ -1,0 +1,9 @@
+require 'rspec'
+require 'appmap/rspec'
+require 'hello'
+
+describe Hello, appmap: 'hello' do
+  it 'says hello', appmap: 'speak' do
+    expect(Hello.new.say_hello).to eq('Hello!')
+  end
+end

--- a/test/fixtures/rspec_recorder/spec/plain_hello_spec.rb
+++ b/test/fixtures/rspec_recorder/spec/plain_hello_spec.rb
@@ -2,8 +2,8 @@ require 'rspec'
 require 'appmap/rspec'
 require 'hello'
 
-describe Hello, feature_group: 'Hello' do
-  it 'says hello', feature: 'Say hello', appmap: true do
+describe Hello, appmap: true do
+  it 'says hello' do
     expect(Hello.new.say_hello).to eq('Hello!')
   end
 end

--- a/test/rspec_test.rb
+++ b/test/rspec_test.rb
@@ -5,18 +5,58 @@ require 'test_helper'
 require 'English'
 
 class RSpecTest < Minitest::Test
-  def test_record_rspec
+  def perform_test(test_name)
     Bundler.with_clean_env do
       Dir.chdir 'test/fixtures/rspec_recorder' do
-        appmap_file = 'tmp/appmap/rspec/Hello_says_hello.json'
         FileUtils.rm_rf 'tmp'
         system 'bundle'
-        system({ 'APPMAP' => 'true' }, 'bundle exec rspec')
-        assert File.file?(appmap_file), 'appmap output file does not exist'
-        assert_includes File.read(appmap_file), %("class":"String","value":"Hello!")
-        assert_includes File.read(appmap_file), %("feature":"Say hello")
-        assert_includes File.read(appmap_file), %("feature_group":"Hello")
+        system({ 'APPMAP' => 'true' }, %(bundle exec rspec spec/#{test_name}.rb))
+
+        yield
       end
+    end
+  end
+
+  def test_record_decorated_rspec
+    perform_test 'decorated_hello_spec' do
+      appmap_file = 'tmp/appmap/rspec/Hello_says_hello.appmap.json'
+
+      assert File.file?(appmap_file), 'appmap output file does not exist'
+      appmap = JSON.parse(File.read(appmap_file))
+      assert_equal AppMap::APPMAP_FORMAT_VERSION, appmap['version']
+      assert_includes appmap.keys, 'metadata'
+      metadata = appmap['metadata']
+      assert_equal 'Saying hello', metadata['feature_group']
+      assert_equal 'Speak hello', metadata['feature']
+      assert_equal 'Hello says hello', metadata['name']
+      assert_includes metadata.keys, 'client'
+      assert_equal({ name: 'appmap', url: AppMap::URL, version: AppMap::VERSION }.stringify_keys, metadata['client'])
+      assert_includes metadata.keys, 'recorder'
+      assert_equal({ name: 'rspec' }.stringify_keys, metadata['recorder'])
+    end
+  end
+
+  def test_record_plain_rspec
+    perform_test 'plain_hello_spec' do
+      appmap_file = 'tmp/appmap/rspec/Hello_says_hello.appmap.json'
+      assert File.file?(appmap_file), 'appmap output file does not exist'
+      appmap = JSON.parse(File.read(appmap_file))
+      assert_includes appmap.keys, 'metadata'
+      metadata = appmap['metadata']
+      assert_equal 'Hello', metadata['feature_group']
+      assert_equal 'Hello', metadata['feature']
+      assert_equal 'Hello says hello', metadata['name']
+    end
+  end
+
+  def test_record_labeled_rspec
+    perform_test 'labeled_hello_spec' do
+      appmap_file = 'tmp/appmap/rspec/Hello_says_hello.appmap.json'
+      assert File.file?(appmap_file), 'appmap output file does not exist'
+      appmap = JSON.parse(File.read(appmap_file))
+      assert_includes appmap.keys, 'metadata'
+      metadata = appmap['metadata']
+      assert_equal %w[hello speak], metadata['labels'].sort
     end
   end
 end


### PR DESCRIPTION
Scenario metadata has `recorder` and `client` fields, to indicate how the data was collected.

Also a couple of bug fixes:

* Handle errors which occur while calling `tp.self.method(tp.method_id).parameters`
* Collect all RSpec `label` tags from the example and its parent example groups
* Improve the test coverage for inference of feature group and feature names in when recording RSpecs.

