### PR TITLE
Include an inventory file in appmap/rspec output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.22.0
+
+* **RSpec** recorder generates an "inventory" (AppMap with classMap, without events) named `Inventory.appmap.json`.
+* **appmap inspect** generates an inventory AppMap which includes `version`, `metadata`, and `classMap`. Previously, the file output by this command was the class map represented as an array.
+
 # v0.21.0
 
 * Scenario data includes `recorder` and `client` info, describing how the data was recorded.

--- a/exe/appmap
+++ b/exe/appmap
@@ -48,8 +48,8 @@ module AppMap
 
       c.action do
         require 'appmap/command/inspect'
-        features = AppMap::Command::Inspect.new(@config).perform
-        @output_file.write JSON.pretty_generate(features)
+        appmap = AppMap::Command::Inspect.new(@config).perform
+        @output_file.write JSON.pretty_generate(appmap)
       end
     end
 

--- a/lib/appmap/command/inspect.rb
+++ b/lib/appmap/command/inspect.rb
@@ -4,7 +4,10 @@ module AppMap
 
     class Inspect < InspectStruct
       def perform
-        AppMap.inspect(config)
+        require 'appmap/command/record'
+
+        features = AppMap.inspect(config)
+        { version: AppMap::APPMAP_FORMAT_VERSION, metadata: AppMap::Command::Record.detect_metadata, classMap: features }
       end
     end
   end

--- a/lib/appmap/command/upload.rb
+++ b/lib/appmap/command/upload.rb
@@ -21,11 +21,10 @@ module AppMap
       def perform
         appmap = data.clone
 
-        # If it's a list, upload it as a classMap
-        if data.is_a?(Hash)
-          events = data.delete('events') || []
-          class_map = data.delete('classMap') || []
+        events = data.delete('events')
+        class_map = data.delete('classMap') || []
 
+        unless events.blank?
           pruned_events = []
           stack = []
           events.each do |evt|
@@ -44,14 +43,11 @@ module AppMap
 
           warn "Pruned events to #{pruned_events.length}" if events.length > pruned_events.length
 
-          events = pruned_events
-
-          class_map = prune(class_map, events: events)
-          appmap[:classMap] = class_map
-          appmap[:events] = events
+          appmap[:events] = pruned_events
+          appmap[:classMap] = prune(class_map, events: pruned_events)
         else
-          class_map = prune(data)
-          appmap = { "version": AppMap::APPMAP_FORMAT_VERSION, "classMap": class_map, "events": [] }
+          appmap[:events] = []
+          appmap[:classMap] = prune(class_map)
         end
 
         upload_file = { user: user, org: org, data: appmap }.compact

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.21.0'
+  VERSION = '0.22.0'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -33,7 +33,16 @@ class CLITest < Minitest::Test
 
     assert_equal 0, $CHILD_STATUS.exitstatus
     assert !output.blank?, 'Output should exist in stdout'
-    JSON.parse(output)
+  end
+
+  def test_inspect_fields
+    output = `./exe/appmap inspect -o -`
+
+    output = JSON.parse(output)
+    assert_includes output.keys, 'version'
+    assert_includes output.keys, 'classMap'
+    assert_includes output.keys, 'metadata'
+    assert !output.keys.include?('events')
   end
 
   def test_record

--- a/test/rspec_test.rb
+++ b/test/rspec_test.rb
@@ -17,6 +17,21 @@ class RSpecTest < Minitest::Test
     end
   end
 
+  def test_inventory
+    perform_test 'plain_hello_spec' do
+      appmap_file = 'tmp/appmap/rspec/Inventory.appmap.json'
+
+      assert File.file?(appmap_file), 'appmap output file does not exist'
+      appmap = JSON.parse(File.read(appmap_file))
+      assert_equal AppMap::APPMAP_FORMAT_VERSION, appmap['version']
+      assert_includes appmap.keys, 'metadata'
+      metadata = appmap['metadata']
+      assert_equal 'Inventory', metadata['name']
+      assert_includes metadata.keys, 'labels'
+      assert_equal metadata['labels'], %w[inventory]
+    end
+  end
+
   def test_record_decorated_rspec
     perform_test 'decorated_hello_spec' do
       appmap_file = 'tmp/appmap/rspec/Hello_says_hello.appmap.json'


### PR DESCRIPTION
RSpec recorder generates an "inventory" (AppMap with classMap, without events) named Inventory.appmap.json

appmap inspect generates an inventory AppMap which includes version, metadata, and classMap. Previously, the file output by this command was the class map represented as an array.