### PR TITLE
Update and fix remote recording routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.24.1
+* Fixes an issue which prevented a remote recording from returning scenario data successfully.
+* Remote recording routes now return descriptive status codes as intended.
+* Remote recording routes now have the correct `Content-Type` header.
+
 # v0.24.0
 
 Internals of `appmap-ruby` have been changed to record each method event using `alias_method`,

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.24.0'
+  VERSION = '0.24.1'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/spec/fixtures/rails_users_app/docker-compose.yml
+++ b/spec/fixtures/rails_users_app/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       [ "./bin/rails", "server", "-b", "0.0.0.0", "webrick" ]
     environment:
       RAILS_ENV:
+      ORM_MODULE:
+      APPMAP:
     volumes:
     - .:/src/app
     ports:

--- a/spec/remote_recording_spec.rb
+++ b/spec/remote_recording_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_spec_helper'
+require 'net/http'
+require 'socket'
+
+describe 'remote recording', :order => :defined do
+  before(:all) { @fixture_dir = 'spec/fixtures/rails_users_app' }
+  include_context 'Rails app pg database'
+  
+  before(:all) do
+    # We should really leave it to Docker to pick a random port for us, but right now we have no
+    # ability to parse the output of `docker port`. This should be sufficient for now.
+    @service_port = rand(30000..60000)
+
+    cmd = 'docker-compose run' \
+      ' -d' \
+      " -p #{@service_port}:3000" \
+      ' -e ORM_MODULE=sequel' \
+      ' -e APPMAP=true' \
+      ' app'
+
+    run_cmd cmd, chdir: @fixture_dir
+
+    service_running = false
+    retry_count = 0
+    uri = URI("http://localhost:#{@service_port}/health")
+
+    until service_running
+      begin
+        res = Net::HTTP.start(uri.hostname, uri.port) do |http|
+          http.request(Net::HTTP::Get.new(uri))
+        end
+
+        service_running = true if res.instance_of?(Net::HTTPNoContent);
+
+        # give up after a certain error threshold is met
+        # we don't want to wait forever if there's an unrecoverable issue
+        raise "gave up waiting on fixture service" if (retry_count += 1) == 10
+      rescue Errno::ETIMEDOUT, Errno::ECONNRESET, EOFError => e
+        sleep(1.0)
+      end
+    end
+  end
+
+  def json_body(res)
+    JSON.parse(res.body).deep_symbolize_keys
+  end
+
+  after(:all) do
+    run_cmd 'docker-compose rm -fs app', chdir: @fixture_dir
+  end
+
+  let(:service_address) { URI("http://localhost:#{@service_port}") }
+  let(:users_path) { "/users" }
+  let(:record_path) { "/_appmap/record" }
+
+  it 'returns the recording status' do
+    res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
+      http.request( Net::HTTP::Get.new(record_path) )
+    }
+
+    expect(res).to be_a(Net::HTTPOK)
+    expect(res['Content-Type']).to eq('application/json')
+    expect(json_body(res)).to eq(enabled: false)
+  end
+
+  it 'starts a new recording session' do
+    res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
+      http.request( Net::HTTP::Post.new(record_path) )
+    }
+
+    expect(res).to be_a(Net::HTTPOK)
+  end
+
+  it 'reflects the recording status' do
+    res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
+      http.request( Net::HTTP::Get.new(record_path) )
+    }
+
+    expect(res).to be_a(Net::HTTPOK)
+    expect(res['Content-Type']).to eq('application/json')
+    expect(json_body(res)).to eq(enabled: true)
+  end
+
+  it 'fails to start a new recording session while recording is already active' do
+    res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
+      http.request( Net::HTTP::Post.new(record_path) )
+    }
+
+    expect(res).to be_a(Net::HTTPConflict)
+  end
+
+  it 'stops recording' do
+    # Generate some events
+    Net::HTTP.start(service_address.hostname, service_address.port) { |http|
+      http.request( Net::HTTP::Get.new(users_path) )
+    }
+
+    res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
+      http.request( Net::HTTP::Delete.new(record_path) )
+    }
+
+    expect(res).to be_a(Net::HTTPOK)
+    expect(res['Content-Type']).to eq('application/json')
+
+    data = json_body(res)
+    expect(data[:metadata]).to be_truthy
+    expect(data[:classMap].length).to be > 0
+    expect(data[:events].length).to be > 0
+  end
+
+  it 'fails to stop recording if there is no active recording session' do
+    res = Net::HTTP.start(service_address.hostname, service_address.port) { |http|
+      http.request( Net::HTTP::Delete.new(record_path) )
+    }
+
+    expect(res).to be_a(Net::HTTPNotFound)
+  end
+end


### PR DESCRIPTION
`DELETE` was previously failing to return scenario data. Status codes are now descriptive as intended. Content-Type headers now accurately reflect their content as intended.