### PR TITLE
Fix frameworks metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ appmap.json
 .vscode
 .byebug_history
 
+/test/fixtures/rspec_recorder/.bundle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.26.1
+
+* Fix a bug that caused duplicate entries in the list of frameworks that appear
+  in the `metadata` section of an appmap.
+  
 # v0.26.0
 
 * **appmap upload** is removed. Upload functionality has been moved to

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -11,7 +11,7 @@ module AppMap
       require 'appmap/command/record'
       @metadata ||= AppMap::Command::Record.detect_metadata
       @metadata.freeze
-      @metadata.dup
+      @metadata.deep_dup
     end
 
     module FeatureAnnotations
@@ -214,7 +214,7 @@ module AppMap
       end
 
       def save(example_name, class_map, events: nil, feature_name: nil, feature_group_name: nil, labels: nil)
-        metadata = RSpec.metadata.dup.tap do |m|
+        metadata = RSpec.metadata.tap do |m|
           m[:name] = example_name
           m[:app] = @config.name
           m[:feature] = feature_name if feature_name

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.26.0'
+  VERSION = '0.26.1'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/test/fixtures/rspec_recorder/Gemfile
+++ b/test/fixtures/rspec_recorder/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'appmap', git: '../../..', branch: `git rev-parse --abbrev-ref HEAD`.strip
+gem 'appmap', git: 'applandinc/appmap-ruby', branch: `git rev-parse --abbrev-ref HEAD`.strip
 gem 'byebug'
 gem 'rspec'

--- a/test/fixtures/rspec_recorder/spec/decorated_hello_spec.rb
+++ b/test/fixtures/rspec_recorder/spec/decorated_hello_spec.rb
@@ -3,6 +3,18 @@ require 'appmap/rspec'
 require 'hello'
 
 describe Hello, feature_group: 'Saying hello' do
+  before do
+    # Trick appmap-ruby into thinking we're a Rails app.
+    stub_const('Rails', double('rails', version: 'fake.0'))
+  end
+
+  # The order of these examples is important. The tests check the
+  # appmap for 'says hello', and we want another example to get run
+  # before it.
+  it 'does not say goodbye', feature: 'Speak hello', appmap: true do
+    expect(Hello.new.say_hello).not_to eq('Goodbye!')
+  end
+
   it 'says hello', feature: 'Speak hello', appmap: true do
     expect(Hello.new.say_hello).to eq('Hello!')
   end

--- a/test/rspec_test.rb
+++ b/test/rspec_test.rb
@@ -9,6 +9,7 @@ class RSpecTest < Minitest::Test
     Bundler.with_clean_env do
       Dir.chdir 'test/fixtures/rspec_recorder' do
         FileUtils.rm_rf 'tmp'
+        system 'bundle config --local local.appmap ../../..'
         system 'bundle'
         system({ 'APPMAP' => 'true' }, %(bundle exec rspec spec/#{test_name}.rb))
 

--- a/test/rspec_test.rb
+++ b/test/rspec_test.rb
@@ -48,6 +48,10 @@ class RSpecTest < Minitest::Test
       assert_equal({ name: 'appmap', url: AppMap::URL, version: AppMap::VERSION }.stringify_keys, metadata['client'])
       assert_includes metadata.keys, 'recorder'
       assert_equal({ name: 'rspec' }.stringify_keys, metadata['recorder'])
+
+      assert_includes metadata.keys, 'frameworks'
+      rspec = metadata['frameworks'].select {|f| f['name'] == 'rspec'}
+      assert_equal 1, rspec.count
     end
   end
 


### PR DESCRIPTION
Ensure that `rspec` only shows up once in `metadata[:frameworks]`.

Also, make sure that the fixture's Gemfile references the local repository for testing.