### PR TITLE
Add ability to hook a method by default, label it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.31.0
+
+* Add the ability to hook methods by default, and optionally add labels to them in the
+  classmap. Use it to hook `ActiveSupport::SecurityUtils.secure_compare`.
+  
 # v0.30.0
 
 * Add support for Minitest.

--- a/lib/appmap.rb
+++ b/lib/appmap.rb
@@ -9,6 +9,7 @@ end
 
 require 'appmap/version'
 require 'appmap/hook'
+require 'appmap/config'
 require 'appmap/trace'
 require 'appmap/class_map'
 require 'appmap/metadata'
@@ -38,8 +39,8 @@ module AppMap
     # the load events won't be seen and the hooks won't activate.
     def initialize(config_file_path = 'appmap.yml')
       warn "Configuring AppMap from path #{config_file_path}"
-      self.configuration = Hook::Config.load_from_file(config_file_path)
-      Hook.hook(configuration)
+      self.configuration = Config.load_from_file(config_file_path)
+      Hook.new(configuration).enable
     end
 
     # tracing can be used to start tracing, stop tracing, and record events.

--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module AppMap
+  Package = Struct.new(:path, :exclude, :labels) do
+    def initialize(path, exclude, labels = nil)
+      super
+    end
+    
+    def to_h
+      {
+        path: path,
+        exclude: exclude.blank? ? nil : exclude,
+        labels: labels.blank? ? nil : labels
+      }.compact
+    end
+  end
+
+  class Config
+    # Methods that should always be hooked, with their containing
+    # package and labels that should be applied to them.
+    HOOKED_METHODS = {
+      'ActiveSupport::SecurityUtils' => {
+        secure_compare: Package.new('active_support', nil, ['security'])
+      }
+    }
+      
+    attr_reader :name, :packages
+    def initialize(name, packages = [])
+      @name = name
+      @packages = packages
+    end
+      
+    class << self
+      # Loads configuration data from a file, specified by the file name.
+      def load_from_file(config_file_name)
+        require 'yaml'
+        load YAML.safe_load(::File.read(config_file_name))
+      end
+
+      # Loads configuration from a Hash.
+      def load(config_data)
+        packages = (config_data['packages'] || []).map do |package|
+          Package.new(package['path'], package['exclude'] || [])
+        end
+        Config.new config_data['name'], packages
+      end
+    end
+
+    def to_h
+      {
+        name: name,
+        packages: packages.map(&:to_h)
+      }
+    end
+
+    def package_for_method(method)
+      location = method.source_location
+      location_file, = location
+      return unless location_file
+
+      defined_class,_,method_name = Hook.qualify_method_name(method)
+      hooked_method = find_hooked_method(defined_class, method_name)
+      return hooked_method if hooked_method
+      
+      location_file = location_file[Dir.pwd.length + 1..-1] if location_file.index(Dir.pwd) == 0
+      packages.find do |pkg|
+        (location_file.index(pkg.path) == 0) &&
+          !pkg.exclude.find { |p| location_file.index(p) }
+      end
+    end
+
+    def included_by_location?(method)
+      !!package_for_method(method)
+    end
+
+    def always_hook?(defined_class, method_name)
+      !!find_hooked_method(defined_class, method_name)
+    end
+
+    def find_hooked_method(defined_class, method_name)
+      find_hooked_class(defined_class)[method_name]
+    end
+    
+    def find_hooked_class(defined_class)
+      HOOKED_METHODS[defined_class] || {}
+    end
+  end
+end

--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -21,15 +21,18 @@ module AppMap
     HOOKED_METHODS = {
       'ActiveSupport::SecurityUtils' => {
         secure_compare: Package.new('active_support', nil, ['security'])
+      },
+      'OpenSSL::X509::Certificate' => {
+        sign: Package.new('openssl', nil, ['security'])
       }
     }
-      
+
     attr_reader :name, :packages
     def initialize(name, packages = [])
       @name = name
       @packages = packages
     end
-      
+
     class << self
       # Loads configuration data from a file, specified by the file name.
       def load_from_file(config_file_name)

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -31,12 +31,11 @@ module AppMap
         end
       end
     end
-    
+
     attr_reader :config
     def initialize(config)
       @config = config
     end
-    
 
     # Observe class loading and hook all methods which match the config.
     def enable &block
@@ -69,7 +68,7 @@ module AppMap
       tp = TracePoint.new(:end) do |tp|
         hook = self
         cls = tp.self
-        
+
         instance_methods = cls.public_instance_methods(false)
         class_methods = cls.singleton_class.public_instance_methods(false) - instance_methods
 
@@ -81,9 +80,9 @@ module AppMap
             disasm = RubyVM::InstructionSequence.disasm(method)
             # Skip methods that have no instruction sequence, as they are obviously trivial.
             next unless disasm
-            
+
             defined_class, method_symbol, method_name = Hook.qualify_method_name(method)
-            method_display_name = [defined_class,method_symbol,method_name].join
+            method_display_name = [defined_class, method_symbol, method_name].join
 
             # Don't try and trace the AppMap methods or there will be
             # a stack overflow in the defined hook method.
@@ -125,7 +124,7 @@ module AppMap
         class_methods.each(&hook_method.call(cls.singleton_class))
       end
 
-      tp.enable &block
+      tp.enable(&block)
     end
   end
 end

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -6,161 +6,126 @@ module AppMap
   class Hook
     LOG = false
 
-    Package = Struct.new(:path, :exclude) do
-      def to_h
-        {
-          path: path,
-          exclude: exclude.blank? ? nil : exclude
-        }.compact
-      end
-    end
-
-    Config = Struct.new(:name, :packages) do
-      class << self
-        # Loads configuration data from a file, specified by the file name.
-        def load_from_file(config_file_name)
-          require 'yaml'
-          load YAML.safe_load(::File.read(config_file_name))
-        end
-
-        # Loads configuration from a Hash.
-        def load(config_data)
-          packages = (config_data['packages'] || []).map do |package|
-            Package.new(package['path'], package['exclude'] || [])
-          end
-          Config.new config_data['name'], packages
-        end
-      end
-
-      def initialize(name, packages = [])
-        super name, packages || []
-      end
-
-      def to_h
-        {
-          name: name,
-          packages: packages.map(&:to_h)
-        }
-      end
-    end
-
     HOOK_DISABLE_KEY = 'AppMap::Hook.disable'
 
     class << self
-      # Observe class loading and hook all methods which match the config.
-      def hook(config = AppMap.configure)
-        package_include_paths = config.packages.map(&:path)
-        package_exclude_paths = config.packages.map do |pkg|
-          pkg.exclude.map do |exclude|
-            File.join(pkg.path, exclude)
-          end
-        end.flatten
-
-        before_hook = lambda do |defined_class, method, receiver, args|
-          require 'appmap/event'
-          call_event = AppMap::Event::MethodCall.build_from_invocation(defined_class, method, receiver, args)
-          AppMap.tracing.record_event call_event, defined_class: defined_class, method: method
-          [ call_event, Time.now ]
+      # Return the class, separator ('.' or '#'), and method name for
+      # the given method.
+      def qualify_method_name(method)
+        if method.owner.singleton_class?
+          # Singleton class names can take two forms:
+          # #<Class:Foo> or
+          # #<Class:#<Bar:0x0123ABC>>. Retrieve the name of
+          # the class from the string.
+          # 
+          # (There really isn't a better way to do this. The
+          # singleton's reference to the class it was created
+          # from is stored in an instance variable named
+          # '__attached__'. It doesn't have the '@' prefix, so
+          # it's internal only, and not accessible from user
+          # code.)
+          class_name = /#<Class:((#<(?<cls>.*?):)|((?<cls>.*?)>))/.match(method.owner.to_s)['cls']
+          [ class_name, '.', method.name ]
+        else
+          [ method.owner.name, '#', method.name ]
         end
+      end
+    end
+    
+    attr_reader :config
+    def initialize(config)
+      @config = config
+    end
+    
 
-        after_hook = lambda do |call_event, defined_class, method, start_time, return_value, exception|
-          require 'appmap/event'
-          elapsed = Time.now - start_time
-          return_event = AppMap::Event::MethodReturn.build_from_invocation \
-            defined_class, method, call_event.id, elapsed, return_value, exception
-          AppMap.tracing.record_event return_event
+    # Observe class loading and hook all methods which match the config.
+    def enable &block
+      before_hook = lambda do |defined_class, method, receiver, args|
+        require 'appmap/event'
+        call_event = AppMap::Event::MethodCall.build_from_invocation(defined_class, method, receiver, args)
+        AppMap.tracing.record_event call_event, defined_class: defined_class, method: method
+        [ call_event, Time.now ]
+      end
+
+      after_hook = lambda do |call_event, defined_class, method, start_time, return_value, exception|
+        require 'appmap/event'
+        elapsed = Time.now - start_time
+        return_event = AppMap::Event::MethodReturn.build_from_invocation \
+                                                     defined_class, method, call_event.id, elapsed, return_value, exception
+        AppMap.tracing.record_event return_event
+      end
+
+      with_disabled_hook = lambda do |&fn|
+        # Don't record functions, such as to_s and inspect, that might be called
+        # by the fn. Otherwise there can be a stack overflow.
+        Thread.current[HOOK_DISABLE_KEY] = true
+        begin
+          fn.call
+        ensure
+          Thread.current[HOOK_DISABLE_KEY] = false
         end
+      end
 
-        with_disabled_hook = lambda do |&fn|
-          # Don't record functions, such as to_s and inspect, that might be called
-          # by the fn. Otherwise there can be a stack oveflow.
-          Thread.current[HOOK_DISABLE_KEY] = true
-          begin
-            fn.call
-          ensure
-            Thread.current[HOOK_DISABLE_KEY] = false
-          end
-        end
+      tp = TracePoint.new(:end) do |tp|
+        hook = self
+        cls = tp.self
+        
+        instance_methods = cls.public_instance_methods(false)
+        class_methods = cls.singleton_class.public_instance_methods(false) - instance_methods
 
-        TracePoint.trace(:end) do |tp|
-          cls = tp.self
+        hook_method = lambda do |cls|
+          lambda do |method_id|
+            next if method_id.to_s =~ /_hooked_by_appmap$/
 
-          instance_methods = cls.public_instance_methods(false)
-          class_methods = cls.singleton_class.public_instance_methods(false) - instance_methods
+            method = cls.public_instance_method(method_id)
+            disasm = RubyVM::InstructionSequence.disasm(method)
+            # Skip methods that have no instruction sequence, as they are obviously trivial.
+            next unless disasm
+            
+            defined_class, method_symbol, method_name = Hook.qualify_method_name(method)
+            method_display_name = [defined_class,method_symbol,method_name].join
 
-          hook_method = lambda do |cls|
-            lambda do |method_id|
-              next if method_id.to_s =~ /_hooked_by_appmap$/
+            # Don't try and trace the AppMap methods or there will be
+            # a stack overflow in the defined hook method.
+            next if /\AAppMap[:\.]/.match?(method_display_name) 
 
-              method = cls.public_instance_method(method_id)
-              location = method.source_location
-              location_file, = location
-              next unless location_file
+            next unless \
+              config.always_hook?(defined_class, method_name) ||
+              config.included_by_location?(method)
 
-              location_file = location_file[Dir.pwd.length + 1..-1] if location_file.index(Dir.pwd) == 0
-              match = package_include_paths.find { |p| location_file.index(p) == 0 }
-              match &&= !package_exclude_paths.find { |p| location_file.index(p) }
-              next unless match
+            warn "AppMap: Hooking #{method_display_name}" if LOG
 
-              disasm = RubyVM::InstructionSequence.disasm(method)
-              # Skip methods that have no instruction sequence, as they are obviously trivial.
-              next unless disasm
+            cls.define_method method_id do |*args, &block|
+              base_method = method.bind(self).to_proc
 
-              defined_class, method_symbol = if method.owner.singleton_class?
-                # Singleton class names can take two forms:
-                # #<Class:Foo> or
-                # #<Class:#<Bar:0x0123ABC>>. Retrieve the name of
-                # the class from the string.
-                # 
-                # (There really isn't a better way to do this. The
-                # singleton's reference to the class it was created
-                # from is stored in an instance variable named
-                # '__attached__'. It doesn't have the '@' prefix, so
-                # it's internal only, and not accessible from user
-                # code.)
-                class_name = /#<Class:((#<(?<cls>.*?):)|((?<cls>.*?)>))/.match(method.owner.to_s)['cls']
-                [ class_name, '.' ]
-              else
-                [ method.owner.name, '#' ]
+              hook_disabled = Thread.current[HOOK_DISABLE_KEY]
+              enabled = true if !hook_disabled && AppMap.tracing.enabled?
+              return base_method.call(*args, &block) unless enabled
+
+              call_event, start_time = with_disabled_hook.call do
+                before_hook.call(defined_class, method, self, args)
               end
-              
-              method_display_name = "#{defined_class}#{method_symbol}#{method.name}"
-              # Don't try and trace the tracing method or there will be a stack overflow
-              # in the defined hook method.
-              next if method_display_name == "AppMap.tracing"
-
-              warn "AppMap: Hooking #{method_display_name}" if LOG
-
-              cls.define_method method_id do |*args, &block|
-                base_method = method.bind(self).to_proc
-
-                hook_disabled = Thread.current[HOOK_DISABLE_KEY]
-                enabled = true if !hook_disabled && AppMap.tracing.enabled?
-                return base_method.call(*args, &block) unless enabled
-
-                call_event, start_time = with_disabled_hook.call do
-                  before_hook.call(defined_class, method, self, args)
-                end
-                return_value = nil
-                exception = nil
-                begin
-                  return_value = base_method.call(*args, &block)
-                rescue
-                  exception = $ERROR_INFO
-                  raise
-                ensure
-                  with_disabled_hook.call do
-                    after_hook.call(call_event, defined_class, method, start_time, return_value, exception)
-                  end
+              return_value = nil
+              exception = nil
+              begin
+                return_value = base_method.call(*args, &block)
+              rescue
+                exception = $ERROR_INFO
+                raise
+              ensure
+                with_disabled_hook.call do
+                  after_hook.call(call_event, defined_class, method, start_time, return_value, exception)
                 end
               end
             end
+          end
         end
 
         instance_methods.each(&hook_method.call(cls))
         class_methods.each(&hook_method.call(cls.singleton_class))
       end
-      end
+
+      tp.enable &block
     end
   end
 end

--- a/lib/appmap/trace.rb
+++ b/lib/appmap/trace.rb
@@ -2,7 +2,15 @@
 
 module AppMap
   module Trace
-    ScopedMethod = Struct.new(:defined_class, :method, :static)
+    class ScopedMethod < SimpleDelegator
+      attr_reader :defined_class, :static
+      
+      def initialize(defined_class, method, static)
+        @defined_class = defined_class
+        @static = static
+        super(method)
+      end
+    end
 
     class Tracing
       def initialize

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.30.0'
+  VERSION = '0.31.0'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_spec_helper'
 require 'active_support/core_ext'
-require 'appmap/hook'
+require 'appmap/config'
 
-describe AppMap::Hook::Config do
+describe AppMap::Config, docker: false do
   it 'loads from a Hash' do
     config_data = {
       name: 'test',
@@ -18,7 +18,7 @@ describe AppMap::Hook::Config do
         }
       ]
     }.deep_stringify_keys!
-    config = AppMap::Hook::Config.load(config_data)
+    config = AppMap::Config.load(config_data)
 
     expect(config.to_h.deep_stringify_keys!).to eq(config_data)
   end

--- a/spec/fixtures/hook/compare.rb
+++ b/spec/fixtures/hook/compare.rb
@@ -1,0 +1,7 @@
+require 'active_support/security_utils'
+
+class Compare
+  def self.compare(s1, s2)
+    ActiveSupport::SecurityUtils.secure_compare(s1, s2)
+  end
+end

--- a/spec/fixtures/hook/openssl_sign.rb
+++ b/spec/fixtures/hook/openssl_sign.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# From the manual page https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL.html
+
+require 'openssl'
+
+module OpenSSLExample
+  def OpenSSLExample.example
+    ca_key = OpenSSL::PKey::RSA.new 2048
+    pass_phrase = 'my secure pass phrase goes here'
+
+    cipher = OpenSSL::Cipher.new 'AES-256-CBC'
+
+    open 'tmp/ca_key.pem', 'w', 0644 do |io|
+      io.write ca_key.export(cipher, pass_phrase)
+    end
+
+    ca_name = OpenSSL::X509::Name.parse '/CN=ca/DC=example'
+
+    ca_cert = OpenSSL::X509::Certificate.new
+    ca_cert.serial = 0
+    ca_cert.version = 2
+    ca_cert.not_before = Time.now
+    ca_cert.not_after = Time.now + 86400
+
+    ca_cert.public_key = ca_key.public_key
+    ca_cert.subject = ca_name
+    ca_cert.issuer = ca_name
+
+    extension_factory = OpenSSL::X509::ExtensionFactory.new
+    extension_factory.subject_certificate = ca_cert
+    extension_factory.issuer_certificate = ca_cert
+
+    ca_cert.add_extension    extension_factory.create_extension('subjectKeyIdentifier', 'hash')
+    ca_cert.add_extension    extension_factory.create_extension('basicConstraints', 'CA:TRUE', true)
+
+    ca_cert.add_extension    extension_factory.create_extension(
+      'keyUsage', 'cRLSign,keyCertSign', true)
+
+    ca_cert.sign ca_key, OpenSSL::Digest::SHA1.new
+
+    open 'tmp/ca_cert.pem', 'w' do |io|
+      io.write ca_cert.to_pem
+    end
+
+    csr = OpenSSL::X509::Request.new
+    csr.version = 0
+    csr.subject = OpenSSL::X509::Name.new([ ['CN', 'the name to sign', OpenSSL::ASN1::UTF8STRING] ])
+    csr.public_key = ca_key.public_key
+    csr.sign ca_key, OpenSSL::Digest::SHA1.new
+
+    open 'tmp/csr.pem', 'w' do |io|
+      io.write csr.to_pem
+    end
+
+    csr = OpenSSL::X509::Request.new File.read 'tmp/csr.pem'
+
+    raise 'CSR can not be verified' unless csr.verify csr.public_key
+
+    csr_cert = OpenSSL::X509::Certificate.new
+    csr_cert.serial = 0
+    csr_cert.version = 2
+    csr_cert.not_before = Time.now
+    csr_cert.not_after = Time.now + 600
+
+    csr_cert.subject = csr.subject
+    csr_cert.public_key = csr.public_key
+    csr_cert.issuer = ca_cert.subject
+
+    extension_factory = OpenSSL::X509::ExtensionFactory.new
+    extension_factory.subject_certificate = csr_cert
+    extension_factory.issuer_certificate = ca_cert
+
+    csr_cert.add_extension    extension_factory.create_extension('basicConstraints', 'CA:FALSE')
+
+    csr_cert.add_extension    extension_factory.create_extension(
+        'keyUsage', 'keyEncipherment,dataEncipherment,digitalSignature')
+
+    csr_cert.add_extension    extension_factory.create_extension('subjectKeyIdentifier', 'hash')
+
+    csr_cert.sign ca_key, OpenSSL::Digest::SHA1.new
+
+    open 'tmp/csr_cert.pem', 'w' do |io|
+      io.write csr_cert.to_pem
+    end
+  end
+end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -61,7 +61,7 @@ describe 'AppMap class Hooking', docker: false do
         AppMap.tracing.delete(tracer)
       end
     end
-    
+
     [ config, tracer ]
   end
 
@@ -408,14 +408,14 @@ describe 'AppMap class Hooking', docker: false do
     events_yaml = <<~YAML
     --- []
     YAML
-    
+
     load 'spec/fixtures/hook/singleton_method.rb'
     setup = -> { SingletonMethod.new_with_instance_method }
     test_hook_behavior 'spec/fixtures/hook/singleton_method.rb', events_yaml, setup: setup do |s|
       expect(s.say_instance_defined).to eq('defined for an instance')
     end
   end
-  
+
   it 'Reports exceptions' do
     events_yaml = <<~YAML
     ---
@@ -453,6 +453,20 @@ describe 'AppMap class Hooking', docker: false do
 
     invoke_test_file 'spec/fixtures/hook/exception_method.rb' do
       expect { ExceptionMethod.new.raise_exception }.to raise_exception
+    end
+  end
+
+  context 'OpenSSL::X509::Certificate.sign' do
+    # OpenSSL::X509 is not being hooked.
+    # This might be because the class is being loaded before AppMap, and so the TracePoint
+    # set by AppMap doesn't see it.
+    xit 'is hooked' do
+      events_yaml = <<~YAML
+      ---
+      YAML
+      test_hook_behavior 'spec/fixtures/hook/openssl_sign.rb', events_yaml do
+        expect(OpenSSLExample.example).to be_truthy
+      end
     end
   end
 
@@ -511,12 +525,12 @@ describe 'AppMap class Hooking', docker: false do
           :class: TrueClass
           :value: 'true'
       YAML
-    
+
       test_hook_behavior 'spec/fixtures/hook/compare.rb', events_yaml do
         expect(Compare.compare('string', 'string')).to be_truthy
       end
     end
-    
+
     it 'gets labeled in the classmap' do
       classmap_yaml = <<~YAML
       ---

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'appmap/util'
 
-describe AppMap::Util do
+describe AppMap::Util, docker: false do
   let(:subject) { AppMap::Util.method(:scenario_filename) }
   describe 'scenario_filename' do
     it 'leaves short names alone' do


### PR DESCRIPTION
There are some methods we'd always like to hook when they're loaded.
These changes add support for that, and add use it to hook
`ActiveSupport::SecurityUtils.secure_compare`.

Also, did a little refactoring, and tagged some specs with
`docker:false` to make them easier to run separately.