### PR TITLE
Don't interfere with methods that use Time.now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.34.1
+* Ensure that capturing events doesn't change the behavior of a hooked method that uses
+  `Time.now`. For example, if a test expects that `Time.now` will be called a certain
+  number of times by a hooked method, that expectation will now be met.
+
 # v0.34.0
 
 * Records builtin security and I/O methods from `OpenSSL`, `Net`, and `IO`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Ensure that capturing events doesn't change the behavior of a hooked method that uses
   `Time.now`. For example, if a test expects that `Time.now` will be called a certain
   number of times by a hooked method, that expectation will now be met.
+* Make sure `appmap/cucumber` requires `appmap`.
 
 # v0.34.0
 

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'selenium-webdriver'
   spec.add_development_dependency 'webdrivers', '~> 4.0'
+  spec.add_development_dependency 'timecop'
 end

--- a/lib/appmap/cucumber.rb
+++ b/lib/appmap/cucumber.rb
@@ -4,6 +4,8 @@ require 'appmap/util'
 
 module AppMap
   module Cucumber
+    APPMAP_OUTPUT_DIR = 'tmp/appmap/cucumber'
+    
     ScenarioAttributes = Struct.new(:name, :feature, :feature_group)
 
     ProviderStruct = Struct.new(:scenario) do
@@ -38,18 +40,27 @@ module AppMap
     end
 
     class << self
+      def init
+        warn 'Configuring AppMap recorder for Cucumber'
+
+        FileUtils.mkdir_p APPMAP_OUTPUT_DIR
+      end
+      
       def write_scenario(scenario, appmap)
         appmap['metadata'] = update_metadata(scenario, appmap['metadata'])
         scenario_filename = AppMap::Util.scenario_filename(appmap['metadata']['name'])
 
-        FileUtils.mkdir_p 'tmp/appmap/cucumber'
-        File.write(File.join('tmp/appmap/cucumber', scenario_filename), JSON.generate(appmap))
+        File.write(File.join(APPMAP_OUTPUT_DIR, scenario_filename), JSON.generate(appmap))
       end
 
       def enabled?
         ENV['APPMAP'] == 'true'
       end
 
+      def run
+        init
+      end
+      
       protected
 
       def cucumber_version
@@ -86,4 +97,10 @@ module AppMap
       end
     end
   end
+end
+
+if AppMap::Cucumber.enabled?
+  require 'appmap'
+
+  AppMap::Cucumber.run
 end

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.34.0'
+  VERSION = '0.34.1'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/spec/fixtures/hook/instance_method.rb
+++ b/spec/fixtures/hook/instance_method.rb
@@ -20,4 +20,8 @@ class InstanceMethod
   def say_block(&block)
     yield
   end
+
+  def say_the_time
+    Time.now.to_s
+  end
 end


### PR DESCRIPTION
Ensure that capturing events doesn't change the behavior of a hooked
method that uses `Time.now`. For example, if a test expects that
`Time.now` will be called a certain number of times by a hooked method,
that expectation will now be met.