### PR TITLE
Add extension to fix Hook.qualify_method_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ Gemfile.lock
 appmap.json
 .vscode
 .byebug_history
-
+/lib/appmap/appmap.bundle

--- a/.rbenv-gemsets
+++ b/.rbenv-gemsets
@@ -1,0 +1,1 @@
+appmap-ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.34.2
+* Add an extension that gets the name of the owner of a singleton method without calling
+  any methods that may have been redefined (e.g. `#to_s` or `.name`).
+  
 # v0.34.1
 * Ensure that capturing events doesn't change the behavior of a hooked method that uses
   `Time.now`. For example, if a test expects that `Time.now` will be called a certain

--- a/README.md
+++ b/README.md
@@ -267,7 +267,13 @@ $ bundle config local.appmap $(pwd)
 Run the tests via `rake`:
 ```
 $ bundle exec rake test
-```  
+```
+
+The `test` target will build the native extension first, then run the tests. If you need
+to build the extension separately, run
+```
+$ bundle exec rake compile
+```
 
 ## Using fixture apps
 
@@ -286,7 +292,7 @@ resources such as a PostgreSQL database.
 To build the fixture container images, first run:
 
 ```sh-session
-$ bundle exec rake fixtures:all
+$ bundle exec rake build:fixtures:all
 ```
 
 This will build the `appmap.gem`, along with a Docker image for each fixture app.

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,13 @@ require 'rdoc/task'
 
 require 'open3'
 
+require "rake/extensiontask"
+
+desc 'build the native extension'
+Rake::ExtensionTask.new("appmap") do |ext|
+  ext.lib_dir = "lib/appmap"
+end
+
 namespace 'gem' do
   require 'bundler/gem_tasks'
 end
@@ -104,7 +111,7 @@ end
 namespace :spec do
   RUBY_VERSIONS.each do |ruby_version|
     desc ruby_version
-    task ruby_version, [:specs] => ["build:fixtures:#{ruby_version}:all"] do |_, task_args|
+    task ruby_version, [:specs] => ["compile", "build:fixtures:#{ruby_version}:all"] do |_, task_args|
       run_specs(ruby_version, task_args)
     end.tap do|t|
       desc "Run all specs"
@@ -119,13 +126,13 @@ Rake::RDocTask.new do |rd|
   rd.title = 'AppMap'
 end
 
-Rake::TestTask.new(:minitest) do |t|
+Rake::TestTask.new(minitest: 'compile') do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/*_test.rb']
 end
 
-task spec: "spec:all"
+task spec: %i[spec:all]
 
 task test: %i[spec:all minitest]
 

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = `git ls-files --no-deleted`.split("
 ")
+  spec.extensions << "ext/appmap/extconf.rb"
+
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
@@ -34,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rdoc'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency "rake-compiler"
 
   # Testing
   spec.add_development_dependency 'climate_control'

--- a/ext/appmap/appmap.c
+++ b/ext/appmap/appmap.c
@@ -1,0 +1,26 @@
+#include <ruby.h>
+#include <ruby/intern.h>
+
+// Seems like CLASS_OR_MODULE_P should really be in a header file in
+// the ruby source -- it's in object.c and duplicated in eval.c.  In
+// the future, we'll fail if it does get moved to a header.
+#define CLASS_OR_MODULE_P(obj) \
+    (!SPECIAL_CONST_P(obj) && \
+     (BUILTIN_TYPE(obj) == T_CLASS || BUILTIN_TYPE(obj) == T_MODULE))
+
+static VALUE singleton_method_owner_name(VALUE klass, VALUE method)
+{
+  VALUE owner = rb_funcall(method, rb_intern("owner"), 0);
+  VALUE attached = rb_ivar_get(owner, rb_intern("__attached__"));
+  if (!CLASS_OR_MODULE_P(attached)) {
+    attached = rb_funcall(attached, rb_intern("class"), 0);
+  }
+  return rb_mod_name(attached);
+}
+    
+void Init_appmap() {
+  VALUE appmap = rb_define_module("AppMap");
+  VALUE hook = rb_define_class_under(appmap, "Hook", rb_cObject);
+
+  rb_define_singleton_method(hook, "singleton_method_owner_name", singleton_method_owner_name, 1);
+}

--- a/ext/appmap/extconf.rb
+++ b/ext/appmap/extconf.rb
@@ -1,0 +1,6 @@
+require "mkmf"
+
+$CFLAGS='-Werror'
+extension_name = "appmap"
+dir_config(extension_name)
+create_makefile(File.join(extension_name, extension_name))

--- a/lib/appmap.rb
+++ b/lib/appmap.rb
@@ -16,6 +16,9 @@ require 'appmap/metadata'
 require 'appmap/util'
 require 'appmap/open'
 
+# load extension
+require 'appmap/appmap'
+
 module AppMap
   class << self
     @configuration = nil

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -17,18 +17,7 @@ module AppMap
       # the given method.
       def qualify_method_name(method)
         if method.owner.singleton_class?
-          # Singleton class names can take two forms:
-          # #<Class:Foo> or
-          # #<Class:#<Bar:0x0123ABC>>. Retrieve the name of
-          # the class from the string.
-          #
-          # (There really isn't a better way to do this. The
-          # singleton's reference to the class it was created
-          # from is stored in an instance variable named
-          # '__attached__'. It doesn't have the '@' prefix, so
-          # it's internal only, and not accessible from user
-          # code.)
-          class_name = /#<Class:((#<(?<cls>.*?):)|((?<cls>.*?)>))/.match(method.owner.to_s)['cls']
+          class_name = singleton_method_owner_name(method)
           [ class_name, '.', method.name ]
         else
           [ method.owner.name, '#', method.name ]

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -47,7 +47,7 @@ module AppMap
             method = hook_cls.public_instance_method(method_id)
             hook_method = Hook::Method.new(hook_cls, method)
 
-            warn "AppMap: Examining #{hook_method.method_display_name}" if LOG
+            warn "AppMap: Examining #{hook_cls} #{method.name}" if LOG
 
             disasm = RubyVM::InstructionSequence.disasm(method)
             # Skip methods that have no instruction sequence, as they are obviously trivial.
@@ -58,7 +58,7 @@ module AppMap
             next if /\AAppMap[:\.]/.match?(hook_method.method_display_name)
 
             next unless \
-              config.always_hook?(hook_method.defined_class, method.name) ||
+              config.always_hook?(hook_cls, method.name) ||
               config.included_by_location?(method)
 
             hook_method.activate

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.34.1'
+  VERSION = '0.34.2'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/spec/fixtures/hook/singleton_method.rb
+++ b/spec/fixtures/hook/singleton_method.rb
@@ -15,6 +15,20 @@ class SingletonMethod
     'defined with self class scope'
   end
 
+  module AddMethod
+    def self.included(base)
+      base.module_eval do
+        define_method "added_method" do
+          _added_method
+        end
+      end
+    end
+    
+    def _added_method
+      'defined by including a module'
+    end
+  end
+  
   # When called, do_include calls +include+ to bring in the module
   # AddMethod. AddMethod defines a new instance method, which gets
   # added to the singleton class of SingletonMethod.
@@ -32,23 +46,18 @@ class SingletonMethod
       end
     end
   end
+
+  STRUCT_TEST = Struct.new(:attr) do
+    class << self
+      def say_struct_singleton
+        'singleton for a struct'
+      end
+    end
+  end
   
   def to_s
     'Singleton Method fixture'
   end
 end
 
-module AddMethod
-  def self.included(base)
-    base.module_eval do
-      define_method "added_method" do
-        _added_method
-      end
-    end
-  end
-  
-  def _added_method
-    'defined by including a module'
-  end
-end
 

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -342,7 +342,7 @@ describe 'AppMap class Hooking', docker: false do
       :defined_class: SingletonMethod
       :method_id: added_method
       :path: spec/fixtures/hook/singleton_method.rb
-      :lineno: 44
+      :lineno: 21
       :static: false
       :parameters: []
       :receiver:
@@ -350,10 +350,10 @@ describe 'AppMap class Hooking', docker: false do
         :value: Singleton Method fixture
     - :id: 2
       :event: :call
-      :defined_class: AddMethod
+      :defined_class: SingletonMethod::AddMethod
       :method_id: _added_method
       :path: spec/fixtures/hook/singleton_method.rb
-      :lineno: 50
+      :lineno: 27
       :static: false
       :parameters: []
       :receiver:
@@ -406,6 +406,33 @@ describe 'AppMap class Hooking', docker: false do
     end
   end
 
+  it 'hooks a singleton method on an embedded struct' do
+    events_yaml = <<~YAML
+    ---
+    - :id: 1
+      :event: :call
+      :defined_class: SingletonMethod::STRUCT_TEST
+      :method_id: say_struct_singleton
+      :path: spec/fixtures/hook/singleton_method.rb
+      :lineno: 52
+      :static: true
+      :parameters: []
+      :receiver:
+        :class: Class
+        :value: SingletonMethod::STRUCT_TEST
+    - :id: 2
+      :event: :return
+      :parent_id: 1
+      :return_value:
+        :class: String
+        :value: singleton for a struct
+    YAML
+
+    test_hook_behavior 'spec/fixtures/hook/singleton_method.rb', events_yaml do
+      expect(SingletonMethod::STRUCT_TEST.say_struct_singleton).to eq('singleton for a struct')
+    end
+  end
+  
   it 'Reports exceptions' do
     events_yaml = <<~YAML
     ---

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -395,6 +395,13 @@ describe 'AppMap class Hooking', docker: false do
     load 'spec/fixtures/hook/singleton_method.rb'
     setup = -> { SingletonMethod.new_with_instance_method }
     test_hook_behavior 'spec/fixtures/hook/singleton_method.rb', events_yaml, setup: setup do |s|
+      # Make sure we're testing the right thing
+      say_instance_defined = s.method(:say_instance_defined)
+      expect(say_instance_defined.owner.to_s).to start_with('#<Class:#<SingletonMethod:')
+
+      # Verify the native extension works as expected
+      expect(AppMap::Hook.singleton_method_owner_name(say_instance_defined)).to eq('SingletonMethod')
+      
       expect(s.say_instance_defined).to eq('defined for an instance')
     end
   end


### PR DESCRIPTION
Add a native extension that allows `qualify_method_name` to avoid any
functions the code being recorded may have redefined (e.g. `#to_s` or
`.name).