### PR TITLE
Don't assume `__attached__.class` is a Module or Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.34.3
+* Fix a crash in `singleton_method_owner_name` that occurred if `__attached__.class` returned
+  something other than a `Module` or a `Class`.
+  
 # v0.34.2
 * Add an extension that gets the name of the owner of a singleton method without calling
   any methods that may have been redefined (e.g. `#to_s` or `.name`).

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -46,4 +46,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'selenium-webdriver'
   spec.add_development_dependency 'webdrivers', '~> 4.0'
   spec.add_development_dependency 'timecop'
+  spec.add_development_dependency 'hashie'
 end

--- a/ext/appmap/appmap.c
+++ b/ext/appmap/appmap.c
@@ -15,7 +15,17 @@ static VALUE singleton_method_owner_name(VALUE klass, VALUE method)
   if (!CLASS_OR_MODULE_P(attached)) {
     attached = rb_funcall(attached, rb_intern("class"), 0);
   }
-  return rb_mod_name(attached);
+
+  // Did __attached__.class return an object that's a Module or a
+  // Class?
+  if (CLASS_OR_MODULE_P(attached)) {
+    // Yup, get it's name
+    return rb_mod_name(attached);
+  }
+
+  // Nope (which seems weird, but whatever). Fall back to calling
+  // #to_s on the method's owner and hope for the best.
+  return rb_funcall(owner, rb_intern("to_s"), 0);
 }
     
 void Init_appmap() {

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.34.2'
+  VERSION = '0.34.3'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -22,7 +22,7 @@ describe 'AppMap class Hooking', docker: false do
       while tracer.event?
         events << tracer.next_event.to_h
       end
-    end.map(&AppMap::Util.method(:sanitize_event)).to_yaml
+    end.map(&AppMap::Util.method(:sanitize_event))
   end
 
   def invoke_test_file(file, setup: nil, &block)
@@ -50,7 +50,7 @@ describe 'AppMap class Hooking', docker: false do
   def test_hook_behavior(file, events_yaml, setup: nil, &block)
     config, tracer = invoke_test_file(file, setup: setup, &block)
 
-    events = collect_events(tracer)
+    events = collect_events(tracer).to_yaml
 
     expect(Diffy::Diff.new(events_yaml, events).to_s).to eq('')
 
@@ -500,7 +500,7 @@ describe 'AppMap class Hooking', docker: false do
         :event: :call
         :defined_class: ActiveSupport::SecurityUtils
         :method_id: secure_compare
-        :path: gems/activesupport-6.0.3.2/lib/active_support/security_utils.rb
+        :path: lib/active_support/security_utils.rb
         :lineno: 26
         :static: true
         :parameters:
@@ -598,7 +598,7 @@ describe 'AppMap class Hooking', docker: false do
             :children:
             - :name: secure_compare
               :type: function
-              :location: gems/activesupport-6.0.3.2/lib/active_support/security_utils.rb:26
+              :location: lib/active_support/security_utils.rb:26
               :static: true
               :labels:
               - security
@@ -624,7 +624,7 @@ describe 'AppMap class Hooking', docker: false do
       config, tracer = invoke_test_file 'spec/fixtures/hook/compare.rb' do
         expect(Compare.compare('string', 'string')).to be_truthy
       end
-      cm = AppMap::ClassMap.build_from_methods(config, tracer.event_methods)
+      cm = AppMap::Util.sanitize_paths(AppMap::ClassMap.build_from_methods(config, tracer.event_methods))
       entry = cm[1][:children][0][:children][0][:children][0]
       # Sanity check, make sure we got the right one
       expect(entry[:name]).to eq('secure_compare')


### PR DESCRIPTION
When getting the class of a singleton method's owner, make sure the
object returned by `__attached__.class` is actually a Module or a Class.
If it is, we can get it's name. If it's not, just call `#to_s` on the
owner's class.

Fixes #74 