### PR TITLE
Fix problem getting database version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.34.4
+* Make sure `AppMap:Rails::SQLExaminer::ActiveRecordExaminer.server_version` only calls
+  `ActiveRecord::Base.connection.database_version` if it's available.
+* Fix `AppMap:Rails::SQLExaminer::ActiveRecordExaminer.database_type` returns `:postgres`
+  in all supported versions of Rails.
+
 # v0.34.3
 * Fix a crash in `singleton_method_owner_name` that occurred if `__attached__.class` returned
   something other than a `Module` or a `Class`.

--- a/lib/appmap/rails/sql_handler.rb
+++ b/lib/appmap/rails/sql_handler.rb
@@ -73,20 +73,15 @@ module AppMap
 
         class ActiveRecordExaminer
           def server_version
-            case database_type
-            when :postgres
-              ActiveRecord::Base.connection.postgresql_version
-            when :sqlite
-              ActiveRecord::Base.connection.database_version.to_s
-            else
-              warn "Unable to determine database version for #{database_type.inspect}"
-            end
+            ActiveRecord::Base.connection.try(:database_version) ||\
+              warn("Unable to determine database version for #{database_type.inspect}")
           end
 
           def database_type
-            return :postgres if ActiveRecord::Base.connection.respond_to?(:postgresql_version)
+            type = ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+            type = :postgres if type == :postgresql
 
-            ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+            type
           end
 
           def execute_query(sql)

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.34.3'
+  VERSION = '0.34.4'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end


### PR DESCRIPTION
`ActiveRecord::Base.connection.server_version` was added in Rails 6.
Don't try to call it unless it's available.