### PR TITLE
Ensure that hooking preserves method arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.34.5
+* Ensure that hooking a method doesn't change its arity.
+
 # v0.34.4
 * Make sure `AppMap:Rails::SQLExaminer::ActiveRecordExaminer.server_version` only calls
   `ActiveRecord::Base.connection.database_version` if it's available.

--- a/ext/appmap/appmap.c
+++ b/ext/appmap/appmap.c
@@ -8,7 +8,12 @@
     (!SPECIAL_CONST_P(obj) && \
      (BUILTIN_TYPE(obj) == T_CLASS || BUILTIN_TYPE(obj) == T_MODULE))
 
-static VALUE singleton_method_owner_name(VALUE klass, VALUE method)
+#define ARITIES_KEY "__arities__"
+
+VALUE am_AppMapHook;
+
+static VALUE
+singleton_method_owner_name(VALUE klass, VALUE method)
 {
   VALUE owner = rb_funcall(method, rb_intern("owner"), 0);
   VALUE attached = rb_ivar_get(owner, rb_intern("__attached__"));
@@ -27,10 +32,64 @@ static VALUE singleton_method_owner_name(VALUE klass, VALUE method)
   // #to_s on the method's owner and hope for the best.
   return rb_funcall(owner, rb_intern("to_s"), 0);
 }
-    
+
+
+static VALUE
+am_define_method_with_arity(VALUE mod, VALUE name, VALUE arity, VALUE proc)
+{
+  VALUE arities_key = rb_intern(ARITIES_KEY);
+  VALUE arities = rb_ivar_get(mod, arities_key);
+  
+  if (arities == Qundef || NIL_P(arities)) {
+    arities = rb_hash_new();
+    rb_ivar_set(mod, arities_key, arities);
+  }
+  rb_hash_aset(arities, name, arity);
+
+  return rb_funcall(mod, rb_intern("define_method"), 2, name, proc);
+}
+
+static VALUE
+am_get_method_arity(VALUE method, VALUE orig_arity_method)
+{
+  VALUE owner = rb_funcall(method, rb_intern("owner"), 0);
+  VALUE arities = rb_ivar_get(owner, rb_intern(ARITIES_KEY));
+  VALUE name = rb_funcall(method, rb_intern("name"), 0);
+  VALUE arity = Qnil;
+  // See if we saved an arity for the method.
+  if (!NIL_P(arities)) {
+    arity = rb_hash_aref(arities, name);
+  }
+  // Didn't find one, call the original method.
+  if (NIL_P(arity)) {
+    VALUE bound_method = rb_funcall(orig_arity_method, rb_intern("bind"), 1, method);    
+    arity = rb_funcall(bound_method, rb_intern("call"), 0);
+  }
+
+  return arity;
+}
+
+static VALUE
+am_unbound_method_arity(VALUE method)
+{
+  VALUE orig_unbound_method_arity = rb_ivar_get(am_AppMapHook, rb_intern("@unbound_method_arity"));
+  return am_get_method_arity(method, orig_unbound_method_arity);
+}
+
+static VALUE
+am_method_arity(VALUE method)
+{
+  VALUE orig_method_arity = rb_ivar_get(am_AppMapHook, rb_intern("@method_arity"));
+  return am_get_method_arity(method, orig_method_arity);
+}
+
 void Init_appmap() {
   VALUE appmap = rb_define_module("AppMap");
-  VALUE hook = rb_define_class_under(appmap, "Hook", rb_cObject);
+  am_AppMapHook = rb_define_class_under(appmap, "Hook", rb_cObject);
 
-  rb_define_singleton_method(hook, "singleton_method_owner_name", singleton_method_owner_name, 1);
+  rb_define_singleton_method(am_AppMapHook, "singleton_method_owner_name", singleton_method_owner_name, 1);
+
+  rb_define_method(rb_cModule, "define_method_with_arity", am_define_method_with_arity, 3);
+  rb_define_method(rb_cUnboundMethod, "arity", am_unbound_method_arity, 0);
+  rb_define_method(rb_cMethod, "arity", am_method_arity, 0);
 }

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -6,6 +6,9 @@ module AppMap
   class Hook
     LOG = (ENV['DEBUG'] == 'true')
 
+    @unbound_method_arity = ::UnboundMethod.instance_method(:arity)
+    @method_arity = ::Method.instance_method(:arity)
+
     class << self
       def lock_builtins
         return if @builtins_hooked

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -43,7 +43,7 @@ module AppMap
         require 'hashie'
         h.extend(Hashie::Extensions::DeepLocate)
         keys = %i(path location)
-        entries = h.deep_locate ->(k,v,o) {
+        h.deep_locate ->(k,v,o) {
           next unless keys.include?(k)
           
           fix = ->(v) {v.gsub(%r{#{Gem.dir}/gems/.*(?=lib)}, '')}

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.34.4'
+  VERSION = '0.34.5'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -669,4 +669,11 @@ describe 'AppMap class Hooking', docker: false do
       end
     end
   end
+
+  it "preserves the arity of hooked methods" do
+    invoke_test_file 'spec/fixtures/hook/instance_method.rb' do
+      expect(InstanceMethod.instance_method(:say_echo).arity).to be(1)
+      expect(InstanceMethod.new.method(:say_echo).arity).to be(1)
+    end
+  end
 end


### PR DESCRIPTION
When hooking a method, we need to create a Proc that accepts the same
arguments as the original method. The only way to do this is with a
splat, i.e. `Proc.new do |*args|...`. Unfortunately, the arity of this
Proc is -1 (because it accepts a variable number of arguments), which
may or may not match the original method.

As far as I was able to determine, Ruby doesn't provide a way to get the
signature of a method and define a Proc with a matching signature. The
closest I came was to consider parsing the array returned from
`#parameters` and reconstructing the original signature. This isn't a
viable approach, because there's no way to obtain the default value for
an optional parameter.

So, instead, when hooking a method, cache its arity in the class that
owns it, and reimplement `#arity` so it uses the cached value. I opted
to do this in the extension with a hidden instance variable to hold the
cache. This avoids the possibility of interfering with any reflection
the app may be doing.