### PR TITLE
Get rid of extra warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.34.6
+* Only warn once about problems determining database version for an ActiveRecord
+  connection.
+
 # v0.34.5
 * Ensure that hooking a method doesn't change its arity.
 

--- a/lib/appmap/rails/sql_handler.rb
+++ b/lib/appmap/rails/sql_handler.rb
@@ -72,9 +72,17 @@ module AppMap
         end
 
         class ActiveRecordExaminer
+          @@db_version_warning_issued = {}
+          
+          def issue_warning
+            db_type = database_type
+            return if @@db_version_warning_issued[db_type]
+            warn("AppMap: Unable to determine database version for #{db_type.inspect}") 
+            @@db_version_warning_issued[db_type] = true
+          end
+          
           def server_version
-            ActiveRecord::Base.connection.try(:database_version) ||\
-              warn("Unable to determine database version for #{database_type.inspect}")
+            ActiveRecord::Base.connection.try(:database_version) || issue_warning
           end
 
           def database_type

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.34.5'
+  VERSION = '0.34.6'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end


### PR DESCRIPTION
Only warn once about problems determining database version for an
ActiveRecord connection.