### PR TITLE
Specify a gem name to record in appmap.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v0.36.0
+* *appmap.yml* package definition may specify `gem`.
 * Skip loading the railtie if `APPMAP_INITIALIZE` environment variable
   is set to `false`.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ name: MyProject
 packages:
 - path: app/controllers
 - path: app/models
+- gem: activerecord
 ```
 
 * **name** Provides the project name (required)
@@ -87,6 +88,7 @@ Each entry in the `packages` list is a YAML object which has the following keys:
 
 * **path** The path to the source code directory. The path may be relative to the current working directory, or it may
   be an absolute path.
+* **gem** As an alternative to specifying the path, specify the name of a dependency gem. When using `gem`, don't specify `path`.
 * **exclude** A list of files and directories which will be ignored. By default, all modules, classes and public
   functions are inspected.
 

--- a/Rakefile
+++ b/Rakefile
@@ -113,7 +113,7 @@ namespace :spec do
     desc ruby_version
     task ruby_version, [:specs] => ["compile", "build:fixtures:#{ruby_version}:all"] do |_, task_args|
       run_specs(ruby_version, task_args)
-    end.tap do|t|
+    end.tap do |t|
       desc "Run all specs"
       task :all, [:specs] => t
     end

--- a/appmap.yml
+++ b/appmap.yml
@@ -1,8 +1,2 @@
 name: AppMap Rubygem
-packages:
-  - path: lib/appmap
-    exclude:
-      - server
-      - trace
-
-  - path: examples
+packages: []

--- a/lib/appmap/class_map.rb
+++ b/lib/appmap/class_map.rb
@@ -83,7 +83,7 @@ module AppMap
 
         object_infos = [
           {
-            name: package.path,
+            name: package.name,
             type: 'package'
           }
         ]

--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -2,15 +2,30 @@
 
 module AppMap
   class Config
-    Package = Struct.new(:path, :package_name, :exclude, :labels) do
-      def initialize(path, package_name: nil, exclude: [], labels: [])
-        super path, package_name, exclude, labels
+    Package = Struct.new(:path, :gem, :package_name, :exclude, :labels) do
+      class << self
+        def build(path: nil, gem: nil, package_name: nil, exclude: [], labels: [])
+          path = gem_path(gem) if gem
+          Package.new(path, gem, package_name, exclude, labels)
+        end
+
+        protected
+
+        def gem_path(gem)
+          gemspec = Gem.loaded_specs[gem] or raise "Gem #{gem.inspect} not found"
+          File.join(gemspec.gem_dir, gemspec.source_paths.first)
+        end
+      end
+
+      def name
+        gem || path
       end
 
       def to_h
         {
           path: path,
           package_name: package_name,
+          gem: gem,
           exclude: exclude.blank? ? nil : exclude,
           labels: labels.blank? ? nil : labels
         }.compact
@@ -20,12 +35,12 @@ module AppMap
     Hook = Struct.new(:method_names, :package) do
     end
 
-    OPENSSL_PACKAGE = Package.new('openssl', package_name: 'openssl', labels: %w[security crypto])
+    OPENSSL_PACKAGE = Package.build(path: 'openssl', package_name: 'openssl', labels: %w[security crypto])
 
     # Methods that should always be hooked, with their containing
     # package and labels that should be applied to them.
     HOOKED_METHODS = {
-      'ActiveSupport::SecurityUtils' => Hook.new(:secure_compare, Package.new('active_support', package_name: 'active_support', labels: %w[security crypto]))
+      'ActiveSupport::SecurityUtils' => Hook.new(:secure_compare, Package.build(path: 'active_support', package_name: 'active_support', labels: %w[security crypto]))
     }.freeze
 
     BUILTIN_METHODS = {
@@ -35,14 +50,14 @@ module AppMap
       'OpenSSL::PKCS5' => Hook.new(%i[pbkdf2_hmac_sha1 pbkdf2_hmac], OPENSSL_PACKAGE),
       'OpenSSL::Cipher' => Hook.new(%i[encrypt decrypt final], OPENSSL_PACKAGE),
       'OpenSSL::X509::Certificate' => Hook.new(:sign, OPENSSL_PACKAGE),
-      'Net::HTTP' => Hook.new(:request, Package.new('net/http', package_name: 'net/http', labels: %w[http io])),
-      'Net::SMTP' => Hook.new(:send, Package.new('net/smtp', package_name: 'net/smtp', labels: %w[smtp email io])),
-      'Net::POP3' => Hook.new(:mails, Package.new('net/pop3', package_name: 'net/pop', labels: %w[pop pop3 email io])),
-      'Net::IMAP' => Hook.new(:send_command, Package.new('net/imap', package_name: 'net/imap', labels: %w[imap email io])),
-      'Marshal' => Hook.new(%i[dump load], Package.new('marshal', labels: %w[serialization marshal])),
-      'Psych' => Hook.new(%i[dump dump_stream load load_stream parse parse_stream], Package.new('yaml', package_name: 'psych', labels: %w[serialization yaml])),
-      'JSON::Ext::Parser' => Hook.new(:parse, Package.new('json', package_name: 'json', labels: %w[serialization json])),
-      'JSON::Ext::Generator::State' => Hook.new(:generate, Package.new('json', package_name: 'json', labels: %w[serialization json]))
+      'Net::HTTP' => Hook.new(:request, Package.build(path: 'net/http', package_name: 'net/http', labels: %w[http io])),
+      'Net::SMTP' => Hook.new(:send, Package.build(path: 'net/smtp', package_name: 'net/smtp', labels: %w[smtp email io])),
+      'Net::POP3' => Hook.new(:mails, Package.build(path: 'net/pop3', package_name: 'net/pop', labels: %w[pop pop3 email io])),
+      'Net::IMAP' => Hook.new(:send_command, Package.build(path: 'net/imap', package_name: 'net/imap', labels: %w[imap email io])),
+      'Marshal' => Hook.new(%i[dump load], Package.build(path: 'marshal', labels: %w[serialization marshal])),
+      'Psych' => Hook.new(%i[dump dump_stream load load_stream parse parse_stream], Package.build(path: 'yaml', package_name: 'psych', labels: %w[serialization yaml])),
+      'JSON::Ext::Parser' => Hook.new(:parse, Package.build(path: 'json', package_name: 'json', labels: %w[serialization json])),
+      'JSON::Ext::Generator::State' => Hook.new(:generate, Package.build(path: 'json', package_name: 'json', labels: %w[serialization json]))
     }.freeze
 
     attr_reader :name, :packages
@@ -62,7 +77,7 @@ module AppMap
       # Loads configuration from a Hash.
       def load(config_data)
         packages = (config_data['packages'] || []).map do |package|
-          Package.new(package['path'], exclude: package['exclude'] || [])
+          Package.build(gem: package['gem'], path: package['path'], exclude: package['exclude'] || [])
         end
         Config.new config_data['name'], packages
       end

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.35.2'
+  VERSION = '0.36.0'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -27,7 +27,7 @@ describe 'AppMap class Hooking', docker: false do
 
   def invoke_test_file(file, setup: nil, &block)
     AppMap.configuration = nil
-    package = AppMap::Config::Package.build(path: file)
+    package = AppMap::Config::Package.build_from_path(file)
     config = AppMap::Config.new('hook_spec', [ package ])
     AppMap.configuration = config
     tracer = nil

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -27,7 +27,7 @@ describe 'AppMap class Hooking', docker: false do
 
   def invoke_test_file(file, setup: nil, &block)
     AppMap.configuration = nil
-    package = AppMap::Config::Package.new(path: file)
+    package = AppMap::Config::Package.build(path: file)
     config = AppMap::Config.new('hook_spec', [ package ])
     AppMap.configuration = config
     tracer = nil

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -27,7 +27,7 @@ describe 'AppMap class Hooking', docker: false do
 
   def invoke_test_file(file, setup: nil, &block)
     AppMap.configuration = nil
-    package = AppMap::Config::Package.new(file)
+    package = AppMap::Config::Package.new(path: file)
     config = AppMap::Config.new('hook_spec', [ package ])
     AppMap.configuration = config
     tracer = nil

--- a/test/fixtures/gem_test/Gemfile
+++ b/test/fixtures/gem_test/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'appmap', git: 'applandinc/appmap-ruby', branch: `git rev-parse --abbrev-ref HEAD`.strip
+gem 'activesupport'
+gem 'byebug'
+gem 'minitest'

--- a/test/fixtures/gem_test/appmap.yml
+++ b/test/fixtures/gem_test/appmap.yml
@@ -1,0 +1,3 @@
+name: gem_test
+packages:
+  - gem: activesupport

--- a/test/fixtures/gem_test/test/to_param_test.rb
+++ b/test/fixtures/gem_test/test/to_param_test.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'appmap/minitest'
+require 'minitest/autorun'
+require 'active_support'
+require 'active_support/core_ext'
+
+class ToParamTest < ::Minitest::Test
+  def test_to_param
+    # record use of a core extension
+    assert_equal 'my+id', 'my+id'.to_param
+  end
+end

--- a/test/gem_test.rb
+++ b/test/gem_test.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'English'
+
+class MinitestTest < Minitest::Test
+  def perform_test(test_name)
+    Bundler.with_clean_env do
+      Dir.chdir 'test/fixtures/gem_test' do
+        FileUtils.rm_rf 'tmp'
+        system 'bundle config --local local.appmap ../../..'
+        system 'bundle'
+        system({ 'APPMAP' => 'true' }, %(bundle exec ruby -Ilib -Itest test/#{test_name}_test.rb))
+
+        yield
+      end
+    end
+  end
+
+  def test_record_gem
+    perform_test 'to_param' do
+      appmap_file = 'tmp/appmap/minitest/To_param_to_param.appmap.json'
+      appmap = JSON.parse(File.read(appmap_file))
+      events = appmap['events']
+      assert_equal 2, events.size
+      assert_equal 'call', events.first['event']
+      assert_equal 'to_param', events.first['method_id']
+      assert_equal "#{Gem.loaded_specs['activesupport'].gem_dir}/lib/active_support/core_ext/object/to_query.rb", events.first['path']
+      assert_equal 'return', events.second['event']
+      assert_equal 1, events.second['parent_id']
+    end
+  end
+end

--- a/test/gem_test.rb
+++ b/test/gem_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 require 'English'
 
 class MinitestTest < Minitest::Test
-  def perform_test(test_name)
+  def perform_gem_test(test_name)
     Bundler.with_clean_env do
       Dir.chdir 'test/fixtures/gem_test' do
         FileUtils.rm_rf 'tmp'
@@ -19,7 +19,7 @@ class MinitestTest < Minitest::Test
   end
 
   def test_record_gem
-    perform_test 'to_param' do
+    perform_gem_test 'to_param' do
       appmap_file = 'tmp/appmap/minitest/To_param_to_param.appmap.json'
       appmap = JSON.parse(File.read(appmap_file))
       events = appmap['events']

--- a/test/minitest_test.rb
+++ b/test/minitest_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 require 'English'
 
 class MinitestTest < Minitest::Test
-  def perform_test(test_name)
+  def perform_minitest_test(test_name)
     Bundler.with_clean_env do
       Dir.chdir 'test/fixtures/minitest_recorder' do
         FileUtils.rm_rf 'tmp'
@@ -19,7 +19,7 @@ class MinitestTest < Minitest::Test
   end
 
   def test_hello
-    perform_test 'hello' do
+    perform_minitest_test 'hello' do
       appmap_file = 'tmp/appmap/minitest/Hello_hello.appmap.json'
 
       assert File.file?(appmap_file), 'appmap output file does not exist'

--- a/test/openssl_test.rb
+++ b/test/openssl_test.rb
@@ -11,7 +11,7 @@ class OpenSSLTest < Minitest::Test
         FileUtils.rm_rf 'tmp'
         system 'bundle config --local local.appmap ../../..'
         system 'bundle'
-        system({ 'APPMAP' => 'true', 'DEBUG' => 'true' }, %(bundle exec ruby lib/openssl_#{test_name}.rb))
+        system({ 'APPMAP' => 'true' }, %(bundle exec ruby lib/openssl_#{test_name}.rb))
 
         yield
       end


### PR DESCRIPTION
Enable appmap.yml to specify a `gem` name to map the gem.

Example:

```
name: gem_test
packages:
  - gem: activesupport
```