### PR TITLE
Fix `MethodEvent#display_string`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.35.2
+* Make sure `MethodEvent#display_string` works when the value's `#to_s` and/or `#inspect`
+  methods have problems.
+  
 # v0.35.1
 * Take out hooking of `IO` and `Logger` methods.
 * Enable logging if either `APPMAP_DEBUG` or `DEBUG` is `true`.

--- a/lib/appmap/event.rb
+++ b/lib/appmap/event.rb
@@ -31,11 +31,6 @@ module AppMap
         def display_string(value)
           return nil unless value
 
-          last_resort_string = lambda do
-            warn "AppMap encountered an error inspecting a #{value.class.name}: #{$!.message}"
-            '*Error inspecting variable*'
-          end
-
           value_string = custom_display_string(value) || default_display_string(value)
 
           (value_string||'')[0...LIMIT].encode('utf-8', invalid: :replace, undef: :replace, replace: '_')
@@ -57,6 +52,11 @@ module AppMap
         end
 
         def default_display_string(value)
+          last_resort_string = lambda do
+            warn "AppMap encountered an error inspecting a #{value.class.name}: #{$!.message}"
+            '*Error inspecting variable*'
+          end
+
           begin
             value.to_s
           rescue NoMethodError

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.35.1'
+  VERSION = '0.35.2'
 
   APPMAP_FORMAT_VERSION = '1.2'
 end

--- a/spec/fixtures/hook/exception_method.rb
+++ b/spec/fixtures/hook/exception_method.rb
@@ -9,3 +9,47 @@ class ExceptionMethod
     raise 'Exception occurred in raise_exception'
   end
 end
+
+# subclass from BasicObject so we don't get #to_s. Requires some
+# hackery to implement the other methods normally provided by Object.
+class NoToSMethod < BasicObject
+  def is_a?(*args)
+    return false
+  end
+
+  def class
+    return ::Class
+  end
+
+  def respond_to?(*args)
+    return false
+  end
+
+  def inspect
+    "NoToSMethod"
+  end
+
+  def say_hello
+    "hello"
+  end
+end
+
+class InspectRaises < NoToSMethod
+  def inspect
+    ::Kernel.raise "#to_s missing, #inspect raises"
+  end
+
+  def say_hello
+    "hello"
+  end
+end
+
+class ToSRaises
+  def to_s
+    raise "#to_s raises"
+  end
+
+  def say_hello
+    "hello"
+  end
+end


### PR DESCRIPTION
Make sure `MethodEvent#display_string` can handle values with
problematic `#to_s` and `#inspect` methods.