### PR TITLE
Capture method source code and comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ appmap.json
 .vscode
 .byebug_history
 /lib/appmap/appmap.bundle
+*.so

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  NewCops: enable
+
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.37.0
+* Capture method source and comment.
+
 # v0.36.0
 * *appmap.yml* package definition may specify `gem`.
 * Skip loading the railtie if `APPMAP_INITIALIZE` environment variable

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+$: << File.join(__dir__, 'lib')
 require 'appmap/version'
 GEM_VERSION = AppMap::VERSION
 

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport'
   spec.add_dependency 'faraday'
   spec.add_dependency 'gli'
+  spec.add_dependency 'method_source'
   spec.add_dependency 'parser'
   spec.add_dependency 'rack'
 

--- a/lib/appmap.rb
+++ b/lib/appmap.rb
@@ -83,8 +83,8 @@ module AppMap
     end
 
     # Builds a class map from a config and a list of Ruby methods.
-    def class_map(methods)
-      ClassMap.build_from_methods(methods)
+    def class_map(methods, options = {})
+      ClassMap.build_from_methods(methods, options)
     end
 
     # Returns default metadata detected from the Ruby system and from the

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -148,7 +148,7 @@ module AppMap
 
         AppMap::RSpec.add_event_methods @trace.event_methods
 
-        class_map = AppMap.class_map(@trace.event_methods)
+        class_map = AppMap.class_map(@trace.event_methods, include_source: false)
 
         description = []
         scope = ScopeExample.new(example)

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.36.0'
+  VERSION = '0.37.0'
 
-  APPMAP_FORMAT_VERSION = '1.2'
+  APPMAP_FORMAT_VERSION = '1.3'
 end

--- a/spec/class_map_spec.rb
+++ b/spec/class_map_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'AppMap::ClassMap' do
+  describe '.build_from_methods' do
+    it 'includes source code if available' do
+      map = AppMap.class_map([scoped_method(method(:test_method))])
+      function = dig_map(map, 5)[0]
+      expect(function[:source]).to include 'test method body'
+      expect(function[:comment]).to include 'test method comment'
+    end
+
+    it 'can omit source code even if available' do
+      map = AppMap.class_map([scoped_method((method :test_method))], include_source: false)
+      function = dig_map(map, 5)[0]
+      expect(function).to_not include(:source)
+      expect(function).to_not include(:comment)
+    end
+
+    # test method comment
+    def test_method
+      'test method body'
+    end
+
+    def scoped_method(method)
+      AppMap::Trace::ScopedMethod.new AppMap::Config::Package.new, method.receiver.class.name, method, false
+    end
+
+    def dig_map(map, depth)
+      return map if depth == 0
+
+      dig_map map[0][:children], depth - 1
+    end
+  end
+end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -112,6 +112,10 @@ describe 'AppMap class Hooking', docker: false do
           :type: function
           :location: spec/fixtures/hook/instance_method.rb:8
           :static: false
+          :source: |2
+              def say_default
+                'default'
+              end
     YAML
   end
 
@@ -713,6 +717,10 @@ describe 'AppMap class Hooking', docker: false do
             :type: function
             :location: spec/fixtures/hook/compare.rb:4
             :static: true
+            :source: |2
+                def self.compare(s1, s2)
+                  ActiveSupport::SecurityUtils.secure_compare(s1, s2)
+                end
       - :name: active_support
         :type: package
         :children:
@@ -729,6 +737,15 @@ describe 'AppMap class Hooking', docker: false do
               :labels:
               - security
               - crypto
+              :comment: |
+                # Constant time string comparison, for variable length strings.
+                #
+                # The values are first processed by SHA256, so that we don't leak length info
+                # via timing attacks.
+              :source: |2
+                    def secure_compare(a, b)
+                      fixed_length_secure_compare(::Digest::SHA256.digest(a), ::Digest::SHA256.digest(b)) && a == b
+                    end
       - :name: openssl
         :type: package
         :children:

--- a/test/expectations/openssl_test_key_sign1.json
+++ b/test/expectations/openssl_test_key_sign1.json
@@ -1,0 +1,54 @@
+[
+  {
+    "name": "lib",
+    "type": "package",
+    "children": [
+      {
+        "name": "Example",
+        "type": "class",
+        "children": [
+          {
+            "name": "sign",
+            "type": "function",
+            "location": "lib/openssl_key_sign.rb:10",
+            "static": true
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "openssl",
+    "type": "package",
+    "children": [
+      {
+        "name": "OpenSSL",
+        "type": "class",
+        "children": [
+          {
+            "name": "PKey",
+            "type": "class",
+            "children": [
+              {
+                "name": "PKey",
+                "type": "class",
+                "children": [
+                  {
+                    "name": "sign",
+                    "type": "function",
+                    "location": "OpenSSL::PKey::PKey#sign",
+                    "static": false,
+                    "labels": [
+                      "security",
+                      "crypto"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/expectations/openssl_test_key_sign1.json
+++ b/test/expectations/openssl_test_key_sign1.json
@@ -11,7 +11,8 @@
             "name": "sign",
             "type": "function",
             "location": "lib/openssl_key_sign.rb:10",
-            "static": true
+            "static": true,
+            "source": "  def Example.sign\n    key = OpenSSL::PKey::RSA.new 2048\n\n    document = 'the document'\n\n    digest = OpenSSL::Digest::SHA256.new\n    key.sign digest, document\n  end\n"
           }
         ]
       }

--- a/test/expectations/openssl_test_key_sign2.json
+++ b/test/expectations/openssl_test_key_sign2.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": 1,
+    "event": "call",
+    "defined_class": "Example",
+    "method_id": "sign",
+    "path": "lib/openssl_key_sign.rb",
+    "lineno": 10,
+    "static": true,
+    "parameters": [
+
+    ],
+    "receiver": {
+      "class": "Module"
+    }
+  },
+  {
+    "id": 2,
+    "event": "call",
+    "defined_class": "OpenSSL::PKey::PKey",
+    "method_id": "sign",
+    "path": "OpenSSL::PKey::PKey#sign",
+    "static": false,
+    "parameters": [
+      {
+        "name": "arg",
+        "class": "OpenSSL::Digest::SHA256",
+        "value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "kind": "req"
+      },
+      {
+        "name": "arg",
+        "class": "String",
+        "value": "the document",
+        "kind": "req"
+      }
+    ],
+    "receiver": {
+      "class": "OpenSSL::PKey::RSA"
+    }
+  },
+  {
+    "id": 3,
+    "event": "return",
+    "parent_id": 2,
+    "return_value": {
+      "class": "String"
+    }
+  },
+  {
+    "id": 4,
+    "event": "return",
+    "parent_id": 1,
+    "return_value": {
+      "class": "String"
+    }
+  }
+]


### PR DESCRIPTION
This change builds on https://github.com/applandinc/appmap/pull/9 to capture method source code and documentation comments in the classmap. Note for RSpec runs to avoid duplication code is only recorded in the inventory file.