### PR TITLE
Fix parameter mapping with keyword and rest arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,10 @@ Layout/HeredocIndentation:
 Layout/LineLength:
   Max: 120
 
+Metrics/BlockLength:
+  ExcludedMethods:
+  - it
+
 Style/MultilineBlockChain:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   NewCops: enable
 
+Layout/CaseIndentation:
+  EnforcedStyle: end
+
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.37.1
+* Fix parameter mapping with keyword and rest arguments.
+
 # v0.37.0
 * Capture method source and comment.
 

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.37.0'
+  VERSION = '0.37.1'
 
   APPMAP_FORMAT_VERSION = '1.3'
 end

--- a/spec/fixtures/hook/instance_method.rb
+++ b/spec/fixtures/hook/instance_method.rb
@@ -17,6 +17,10 @@ class InstanceMethod
     kw.to_s
   end
 
+  def say_kws(*args, kw1:, kw2: 'kw2', **kws)
+    [kw1, kw2, kws, args].join
+  end
+
   def say_block(&block)
     yield
   end


### PR DESCRIPTION
This change makes argument handling a bit smarter, to correctly extract keyword and rest arguments.
Thanks to @flywithmemsl for inspiration. See https://github.com/applandinc/appmap-ruby/pull/85 for the original implementation.