### PR TITLE
Record "view" rendering, and implement API "surface" recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.0
+
+* Package configuration can be `shallow`, in case which only the initial entry into the package is recorded.
+
 # v0.37.2
 * Fix ParameterFilter deprecation warning.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.0.0
+# v0.38.0
 
 * Package configuration can be `shallow`, in case which only the initial entry into the package is recorded.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Each entry in the `packages` list is a YAML object which has the following keys:
 * **gem** As an alternative to specifying the path, specify the name of a dependency gem. When using `gem`, don't specify `path`.
 * **exclude** A list of files and directories which will be ignored. By default, all modules, classes and public
   functions are inspected.
+* **shallow** When set to `true`, only the first function call entry into a package will be recorded. Subsequent function calls within 
+  the same package are not recorded unless code execution leaves the package and re-enters it. Default: `true` when using `gem`,
+  `false` when using `path`.
 
 # Running
 

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -39,6 +39,7 @@ module AppMap
         end
 
         defined_class = @defined_class
+        hook_package = self.hook_package
         hook_method = self.hook_method
         before_hook = self.method(:before_hook)
         after_hook = self.method(:after_hook)
@@ -48,29 +49,33 @@ module AppMap
         hook_class.instance_eval do 
           hook_method_def = Proc.new do |*args, &block|
             instance_method = hook_method.bind(self).to_proc
+            call_instance_method = -> { instance_method.call(*args, &block) }
 
             # We may not have gotten the class for the method during
             # initialization (e.g. for a singleton method on an embedded
             # struct), so make sure we have it now.
-            defined_class,_ = Hook.qualify_method_name(hook_method) unless defined_class
+            defined_class, = Hook.qualify_method_name(hook_method) unless defined_class
 
-            hook_disabled = Thread.current[HOOK_DISABLE_KEY]
-            enabled = true if !hook_disabled && AppMap.tracing.enabled?
-            return instance_method.call(*args, &block) unless enabled
+            return call_instance_method.call unless AppMap.tracing.enabled?
 
-            call_event, start_time = with_disabled_hook.() do
-              before_hook.(self, defined_class, args)
+            return call_instance_method.call if Thread.current[HOOK_DISABLE_KEY]
+
+            return call_instance_method.call \
+              if hook_package&.shallow? && AppMap.tracing.last_package_for_current_thread == hook_package
+
+            call_event, start_time = with_disabled_hook.call do
+              before_hook.call(self, defined_class, args)
             end
             return_value = nil
             exception = nil
             begin
-              return_value = instance_method.(*args, &block)
+              return_value = call_instance_method.call
             rescue
               exception = $ERROR_INFO
               raise
             ensure
-              with_disabled_hook.() do
-                after_hook.(self, call_event, start_time, return_value, exception)
+              with_disabled_hook.call do
+                after_hook.call(self, call_event, start_time, return_value, exception)
               end
             end
           end
@@ -87,7 +92,7 @@ module AppMap
         [ call_event, TIME_NOW.call ]
       end
 
-      def after_hook(receiver, call_event, start_time, return_value, exception)
+      def after_hook(_receiver, call_event, start_time, return_value, exception)
         require 'appmap/event'
         elapsed = TIME_NOW.call - start_time
         return_event = \
@@ -95,12 +100,12 @@ module AppMap
         AppMap.tracing.record_event return_event
       end
 
-      def with_disabled_hook(&fn)
+      def with_disabled_hook(&function)
         # Don't record functions, such as to_s and inspect, that might be called
         # by the fn. Otherwise there can be a stack overflow.
         Thread.current[HOOK_DISABLE_KEY] = true
         begin
-          fn.call
+          function.call
         ensure
           Thread.current[HOOK_DISABLE_KEY] = false
         end

--- a/lib/appmap/trace.rb
+++ b/lib/appmap/trace.rb
@@ -34,7 +34,7 @@ module AppMap
       end
 
       def last_package_for_current_thread
-        @tracers.map(&:last_package_for_current_thread).first
+        @tracers.first&.last_package_for_current_thread
       end
 
       def record_event(event, package: nil, defined_class: nil, method: nil)

--- a/lib/appmap/trace.rb
+++ b/lib/appmap/trace.rb
@@ -15,34 +15,38 @@ module AppMap
 
     class Tracing
       def initialize
-        @tracing = []
+        @tracers = []
       end
 
       def empty?
-        @tracing.empty?
+        @tracers.empty?
       end
 
       def trace(enable: true)
         Tracer.new.tap do |tracer|
-          @tracing << tracer
+          @tracers << tracer
           tracer.enable if enable
         end
       end
 
       def enabled?
-        @tracing.any?(&:enabled?)
+        @tracers.any?(&:enabled?)
+      end
+
+      def last_package_for_current_thread
+        @tracers.map(&:last_package_for_current_thread).first
       end
 
       def record_event(event, package: nil, defined_class: nil, method: nil)
-        @tracing.each do |tracer|
+        @tracers.each do |tracer|
           tracer.record_event(event, package: package, defined_class: defined_class, method: method)
         end
       end
 
       def delete(tracer)
-        return unless @tracing.member?(tracer)
+        return unless @tracers.member?(tracer)
 
-        @tracing.delete(tracer)
+        @tracers.delete(tracer)
         tracer.disable
       end
     end
@@ -52,6 +56,7 @@ module AppMap
     # Records the events which happen in a program.
     def initialize
       @events = []
+      @last_package_for_thread = {}
       @methods = Set.new
       @enabled = false
     end
@@ -75,9 +80,15 @@ module AppMap
     def record_event(event, package: nil, defined_class: nil, method: nil)
       return unless @enabled
 
+      @last_package_for_thread[Thread.current.object_id] = package if package
       @events << event
       @methods << Trace::ScopedMethod.new(package, defined_class, method, event.static) \
         if package && defined_class && method && (event.event == :call)
+    end
+
+    # Gets the last package which was observed on the current thread.
+    def last_package_for_current_thread
+      @last_package_for_thread[Thread.current.object_id]
     end
 
     # Gets a unique list of the methods that were invoked by the program.

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.37.2'
+  VERSION = '1.0.0'
 
   APPMAP_FORMAT_VERSION = '1.3'
 end

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '1.0.0'
+  VERSION = '0.38.0'
 
   APPMAP_FORMAT_VERSION = '1.3'
 end

--- a/spec/abstract_controller_base_spec.rb
+++ b/spec/abstract_controller_base_spec.rb
@@ -86,6 +86,7 @@ describe 'AbstractControllerBase' do
             expect(event.keys).to eq(%w[id event thread_id parent_id elapsed return_value])
           end
         end
+
         describe 'listing users' do
           let(:spec_name) { 'spec/controllers/users_controller_spec.rb:11' }
           let(:appmap_json_file) { File.join(tmpdir, 'appmap/rspec/UsersController_GET_users_lists_the_users.appmap.json') }
@@ -113,6 +114,7 @@ describe 'AbstractControllerBase' do
     end
   end
 
-  it_behaves_like 'rails version', '5'
-  it_behaves_like 'rails version', '6'
+  %w[5 6].each do |version|
+    it_behaves_like 'rails version', version
+  end
 end

--- a/spec/abstract_controller_base_spec.rb
+++ b/spec/abstract_controller_base_spec.rb
@@ -3,61 +3,65 @@ require 'rails_spec_helper'
 describe 'AbstractControllerBase' do
   shared_examples 'rails version' do |rails_major_version|
     include_context 'Rails app pg database', "spec/fixtures/rails#{rails_major_version}_users_app" do
-      around(:each) do |example|
+      def run_spec(spec_name)
+        cmd = "docker-compose run --rm -e APPMAP=true -v #{File.absolute_path tmpdir}:/app/tmp app ./bin/rspec #{spec_name}"
+        run_cmd cmd, chdir: fixture_dir
+      end
+
+      before do
         FileUtils.rm_rf tmpdir
         FileUtils.mkdir_p tmpdir
-        cmd = "docker-compose run --rm -e APPMAP=true -v #{File.absolute_path tmpdir}:/app/tmp app ./bin/rspec spec/controllers/users_controller_api_spec.rb:8"
-        run_cmd cmd, chdir: fixture_dir
-
-        example.run
+        run_spec spec_name
       end
 
       let(:tmpdir) { 'tmp/spec/AbstractControllerBase' }
-      let(:create_user_appmap_json) { File.join(tmpdir, 'appmap/rspec/Api_UsersController_POST_api_users_with_required_parameters_creates_a_user.appmap.json') }
-      let(:list_users_appmap_json) { File.join(tmpdir, 'appmap/rspec/UsersController_GET_users_lists_the_users.appmap.json') }
 
       describe 'testing with rspec' do
-        it 'inventory file is printed' do
-          expect(File).to exist(File.join(tmpdir, 'appmap/rspec/Inventory.appmap.json'))
-        end
+        let(:spec_name) { 'spec/controllers/users_controller_api_spec.rb:8' }
+        let(:appmap_json_file) { File.join(tmpdir, 'appmap/rspec/Api_UsersController_POST_api_users_with_required_parameters_creates_a_user.appmap.json') }
 
-        it 'message fields are recorded in the appmap' do
-          expect(File).to exist(create_user_appmap_json)
-          appmap = JSON.parse(File.read(create_user_appmap_json)).to_yaml
+        describe 'creating a user' do
+          it 'inventory file is printed' do
+            expect(File).to exist(File.join(tmpdir, 'appmap/rspec/Inventory.appmap.json'))
+          end
 
-          expect(appmap).to include(<<-MESSAGE.strip)
+          it 'message fields are recorded in the appmap' do
+            expect(File).to exist(appmap_json_file)
+            appmap = JSON.parse(File.read(appmap_json_file)).to_yaml
+
+            expect(appmap).to include(<<-MESSAGE.strip)
   message:
   - name: login
     class: String
     value: alice
     object_id:
-          MESSAGE
+            MESSAGE
 
-          expect(appmap).to include(<<-MESSAGE.strip)
+            expect(appmap).to include(<<-MESSAGE.strip)
   - name: password
     class: String
     value: "[FILTERED]"
     object_id:
-          MESSAGE
+            MESSAGE
 
-          expect(appmap).to include(<<-SERVER_REQUEST.strip)
+            expect(appmap).to include(<<-SERVER_REQUEST.strip)
   http_server_request:
     request_method: POST
     path_info: "/api/users"
-          SERVER_REQUEST
+            SERVER_REQUEST
 
-          expect(appmap).to include(<<-SERVER_RESPONSE.strip)
+            expect(appmap).to include(<<-SERVER_RESPONSE.strip)
   http_server_response:
     status: 201
     mime_type: application/json; charset=utf-8
-          SERVER_RESPONSE
-        end
+            SERVER_RESPONSE
+          end
 
-        it 'properly captures method parameters in the appmap' do
-          expect(File).to exist(create_user_appmap_json)
-          appmap = JSON.parse(File.read(create_user_appmap_json)).to_yaml
+          it 'properly captures method parameters in the appmap' do
+            expect(File).to exist(appmap_json_file)
+            appmap = JSON.parse(File.read(appmap_json_file)).to_yaml
 
-          expect(appmap).to match(<<-CREATE_CALL.strip)
+            expect(appmap).to match(<<-CREATE_CALL.strip)
   event: call
   thread_id: .*
   defined_class: Api::UsersController
@@ -72,14 +76,24 @@ describe 'AbstractControllerBase' do
     value: '{"login"=>"alice"}'
     kind: req
   receiver:
-          CREATE_CALL
+            CREATE_CALL
+          end
+
+          it 'returns a minimal event' do
+            expect(File).to exist(appmap_json_file)
+            appmap = JSON.parse(File.read(appmap_json_file))
+            event = appmap['events'].find { |event| event['event'] == 'return' && event['return_value'] }
+            expect(event.keys).to eq(%w[id event thread_id parent_id elapsed return_value])
+          end
         end
+        describe 'listing users' do
+          let(:spec_name) { 'spec/controllers/users_controller_spec.rb:11' }
+          let(:appmap_json_file) { File.join(tmpdir, 'appmap/rspec/UsersController_GET_users_lists_the_users.appmap.json') }
+          it 'records and labels view rendering' do
+            expect(File).to exist(appmap_json_file)
+            appmap = JSON.parse(File.read(appmap_json_file)).to_yaml
 
-        it 'records and labels view rendering' do
-          expect(File).to exist(list_users_appmap_json)
-          appmap = JSON.parse(File.read(list_users_appmap_json)).to_yaml
-
-          expect(appmap).to match(<<-VIEW_CALL.strip)
+            expect(appmap).to match(<<-VIEW_CALL.strip)
   event: call
   thread_id: .*
   defined_class: ActionView::Renderer
@@ -87,18 +101,13 @@ describe 'AbstractControllerBase' do
   path: .*
   lineno: .*
   static: false
-          VIEW_CALL
+            VIEW_CALL
 
-          expect(appmap).to match(<<-VIEW_LABEL.strip)
-          "labels":["view"]
-          VIEW_LABEL
-        end
-
-        it 'returns a minimal event' do
-          expect(File).to exist(create_user_appmap_json)
-          appmap = JSON.parse(File.read(create_user_appmap_json))
-          event = appmap['events'].find { |event| event['event'] == 'return' && event['return_value'] }
-          expect(event.keys).to eq(%w[id event thread_id parent_id elapsed return_value])
+            expect(appmap).to match(<<-VIEW_LABEL.strip)
+        labels:
+        - view
+            VIEW_LABEL
+          end
         end
       end
     end

--- a/spec/abstract_controller_base_spec.rb
+++ b/spec/abstract_controller_base_spec.rb
@@ -13,7 +13,8 @@ describe 'AbstractControllerBase' do
       end
 
       let(:tmpdir) { 'tmp/spec/AbstractControllerBase' }
-      let(:appmap_json) { File.join(tmpdir, 'appmap/rspec/Api_UsersController_POST_api_users_with_required_parameters_creates_a_user.appmap.json') }
+      let(:create_user_appmap_json) { File.join(tmpdir, 'appmap/rspec/Api_UsersController_POST_api_users_with_required_parameters_creates_a_user.appmap.json') }
+      let(:list_users_appmap_json) { File.join(tmpdir, 'appmap/rspec/UsersController_GET_users_lists_the_users.appmap.json') }
 
       describe 'testing with rspec' do
         it 'inventory file is printed' do
@@ -21,8 +22,8 @@ describe 'AbstractControllerBase' do
         end
 
         it 'message fields are recorded in the appmap' do
-          expect(File).to exist(appmap_json)
-          appmap = JSON.parse(File.read(appmap_json)).to_yaml
+          expect(File).to exist(create_user_appmap_json)
+          appmap = JSON.parse(File.read(create_user_appmap_json)).to_yaml
 
           expect(appmap).to include(<<-MESSAGE.strip)
   message:
@@ -53,8 +54,8 @@ describe 'AbstractControllerBase' do
         end
 
         it 'properly captures method parameters in the appmap' do
-          expect(File).to exist(appmap_json)
-          appmap = JSON.parse(File.read(appmap_json)).to_yaml
+          expect(File).to exist(create_user_appmap_json)
+          appmap = JSON.parse(File.read(create_user_appmap_json)).to_yaml
 
           expect(appmap).to match(<<-CREATE_CALL.strip)
   event: call
@@ -74,9 +75,28 @@ describe 'AbstractControllerBase' do
           CREATE_CALL
         end
 
+        it 'records and labels view rendering' do
+          expect(File).to exist(list_users_appmap_json)
+          appmap = JSON.parse(File.read(list_users_appmap_json)).to_yaml
+
+          expect(appmap).to match(<<-VIEW_CALL.strip)
+  event: call
+  thread_id: .*
+  defined_class: ActionView::Renderer
+  method_id: render
+  path: .*
+  lineno: .*
+  static: false
+          VIEW_CALL
+
+          expect(appmap).to match(<<-VIEW_LABEL.strip)
+          "labels":["view"]
+          VIEW_LABEL
+        end
+
         it 'returns a minimal event' do
-          expect(File).to exist(appmap_json)
-          appmap = JSON.parse(File.read(appmap_json))
+          expect(File).to exist(create_user_appmap_json)
+          appmap = JSON.parse(File.read(create_user_appmap_json))
           event = appmap['events'].find { |event| event['event'] == 'return' && event['return_value'] }
           expect(event.keys).to eq(%w[id event thread_id parent_id elapsed return_value])
         end

--- a/spec/fixtures/rails5_users_app/Gemfile
+++ b/spec/fixtures/rails5_users_app/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-gem 'rails', '~> 6'
+gem 'rails', '~> 5'
 
 gem 'haml-rails'
 

--- a/spec/fixtures/rails5_users_app/appmap.yml
+++ b/spec/fixtures/rails5_users_app/appmap.yml
@@ -1,7 +1,4 @@
 name: rails5_users_app
 packages:
   - path: app
-  - gem: activerecord
   - gem: sequel
-  - gem: pg
-  - gem: rack

--- a/spec/fixtures/rails5_users_app/appmap.yml
+++ b/spec/fixtures/rails5_users_app/appmap.yml
@@ -1,3 +1,7 @@
 name: rails5_users_app
 packages:
   - path: app
+  - gem: activerecord
+  - gem: sequel
+  - gem: pg
+  - gem: rack

--- a/spec/fixtures/rails5_users_app/spec/controllers/users_controller_api_spec.rb
+++ b/spec/fixtures/rails5_users_app/spec/controllers/users_controller_api_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::UsersController, feature_group: 'Users', type: :controller, 
       post :create, params: { login: 'alice' }
     end
     it 'lists the users' do
-      post :index, params: {}
+      get :index, params: {}
       users = JSON.parse(response.body)
       expect(users.map { |r| r['login'] }).to include('alice')
     end

--- a/spec/fixtures/rails5_users_app/spec/controllers/users_controller_spec.rb
+++ b/spec/fixtures/rails5_users_app/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+require 'rack/test'
+
+RSpec.describe UsersController, type: :controller do
+  render_views
+
+  describe 'GET /users', feature: 'Show all users' do
+    before do
+      User.create login: 'alice'
+    end
+    it 'lists the users' do
+      get :index
+      expect(response).to be_ok
+    end
+  end
+end

--- a/spec/fixtures/rails6_users_app/Gemfile
+++ b/spec/fixtures/rails6_users_app/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.2.3'
+gem 'rails', '~> 6'
 
 gem 'haml-rails'
 

--- a/spec/fixtures/rails6_users_app/appmap.yml
+++ b/spec/fixtures/rails6_users_app/appmap.yml
@@ -1,3 +1,5 @@
 name: rails6_users_app
 packages:
   - path: app
+  - gem: sequel
+

--- a/spec/fixtures/rails6_users_app/spec/controllers/users_controller_api_spec.rb
+++ b/spec/fixtures/rails6_users_app/spec/controllers/users_controller_api_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::UsersController, feature_group: 'Users', type: :controller, 
       post :create, params: { login: 'alice' }
     end
     it 'lists the users' do
-      post :index, params: {}
+      get :index, params: {}
       users = JSON.parse(response.body)
       expect(users.map { |r| r['login'] }).to include('alice')
     end

--- a/spec/fixtures/rails6_users_app/spec/controllers/users_controller_spec.rb
+++ b/spec/fixtures/rails6_users_app/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+require 'rack/test'
+
+RSpec.describe UsersController, type: :controller do
+  render_views
+
+  describe 'GET /users', feature: 'Show all users' do
+    before do
+      User.create login: 'alice'
+    end
+    it 'lists the users' do
+      get :index
+      expect(response).to be_ok
+    end
+  end
+end


### PR DESCRIPTION
* Implement API "surface" recording. When `shallow: true`, only the first function call entering a package is recorded. Subsequent functions within the package are not recorded. When recording gems using the `gem: <gem_name>` option in appmap.yml, shallow recording is the default.
* Record `ActionView::Renderer#render` automatically, and apply the label `view`.
* Update the gem version to `1.0.0`.

Regarding the tests on Travis ; `appmap-ruby` is broken on Travis for some reason. I have sent a note to their support. Meanwhile, I ran the test suite locally on a clean checkout and it passed.
