### PR TITLE
Add a global exclude list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.41.0
+
+* Adjust some label names to match `provider.*`, `format.*`.
+* Add global `exclude` list to *appmap.yml* which can be used to definitively exclude specific classes and methods.
+
 # v0.40.0
 
 * Parse source code comments into function labels.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ When you run your program, the `appmap` gem reads configuration settings from `a
 file for a typical Rails project:
 
 ```yaml
-name: MyProject
+# 'name' should generally be the same as the code repo name.
+name: my_project
 packages:
 - path: app/controllers
 - path: app/models
@@ -91,10 +92,15 @@ packages:
 - gem: devise
 - gem: aws-sdk
 - gem: will_paginate
+exclude:
+- MyClass
+- MyClass#my_instance_method
+- MyClass.my_class_method
 ```
 
 * **name** Provides the project name (required)
-* **packages** A list of source code directories which should be instrumented.
+* **packages** A list of source code directories which should be recorded.
+* **exclude** A list of classes and/or methods to definitively exclude from recording.
 
 **packages**
 
@@ -104,10 +110,15 @@ Each entry in the `packages` list is a YAML object which has the following keys:
   be an absolute path.
 * **gem** As an alternative to specifying the path, specify the name of a dependency gem. When using `gem`, don't specify `path`.
 * **exclude** A list of files and directories which will be ignored. By default, all modules, classes and public
-  functions are inspected.
+  functions are inspected. See also: global `exclude` list.
 * **shallow** When set to `true`, only the first function call entry into a package will be recorded. Subsequent function calls within 
   the same package are not recorded unless code execution leaves the package and re-enters it. Default: `true` when using `gem`,
   `false` when using `path`.
+
+**exclude**
+
+Optional list of fully qualified class and method names. Separate class and method names with period (`.`) for class methods and hash (`#`) for instance methods.
+
 
 # Labels
 

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.40.0'
+  VERSION = '0.41.0'
 
   APPMAP_FORMAT_VERSION = '1.4'
 end

--- a/spec/abstract_controller_base_spec.rb
+++ b/spec/abstract_controller_base_spec.rb
@@ -8,7 +8,7 @@ describe 'AbstractControllerBase' do
         FileUtils.rm_rf tmpdir
         FileUtils.mkdir_p tmpdir
         cmd = <<~CMD.gsub "\n", ' '
-          docker-compose run --rm -e APPMAP=true
+          docker-compose run --rm -e RAILS_ENV=test -e APPMAP=true
           -v #{File.absolute_path tmpdir}:/app/tmp app ./bin/rspec #{spec_name}
         CMD
         run_cmd cmd, chdir: fixture_dir

--- a/spec/abstract_controller_base_spec.rb
+++ b/spec/abstract_controller_base_spec.rb
@@ -137,7 +137,7 @@ describe 'AbstractControllerBase' do
                   'name' => 'Renderer',
                   'children' => include(hash_including(
                     'name' => 'render',
-                    'labels' => ['view']
+                    'labels' => ['mvc.view']
                   ))
                 ))
               ))

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -7,6 +7,7 @@ require 'appmap/config'
 describe AppMap::Config, docker: false do
   it 'loads from a Hash' do
     config_data = {
+      exclude: [],
       name: 'test',
       packages: [
         {

--- a/spec/fixtures/hook/exclude.rb
+++ b/spec/fixtures/hook/exclude.rb
@@ -1,0 +1,15 @@
+class ExcludeTest
+  def instance_method
+    'instance_method'
+  end
+
+  class << self
+    def singleton_method
+      'singleton_method'
+    end
+  end
+
+  def self.cls_method
+    'class_method'
+  end
+end

--- a/spec/fixtures/rails5_users_app/appmap.yml
+++ b/spec/fixtures/rails5_users_app/appmap.yml
@@ -1,4 +1,7 @@
 name: rails5_users_app
 packages:
-  - path: app
+  - path: app/models
+    labels: [ mvc.model ]
+  - path: app/controllers
+    labels: [ mvc.controller ]
   - gem: sequel

--- a/spec/fixtures/rails6_users_app/appmap.yml
+++ b/spec/fixtures/rails6_users_app/appmap.yml
@@ -1,5 +1,8 @@
 name: rails6_users_app
 packages:
-  - path: app
+  - path: app/models
+    labels: [ mvc.model ]
+  - path: app/controllers
+    labels: [ mvc.controller ]
   - gem: sequel
 

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -61,6 +61,16 @@ describe 'AppMap class Hooking', docker: false do
     AppMap.configuration = nil
   end
 
+  it 'excludes named classes and methods' do
+    load 'spec/fixtures/hook/exclude.rb'
+    package = AppMap::Config::Package.build_from_path('spec/fixtures/hook/exclude.rb')
+    config = AppMap::Config.new('hook_spec', [ package ], %w[ExcludeTest])
+    AppMap.configuration = config
+
+    expect(config.never_hook?(ExcludeTest.new.method(:instance_method))).to be_truthy
+    expect(config.never_hook?(ExcludeTest.method(:cls_method))).to be_truthy
+  end
+
   it 'parses labels from comments' do
     _, tracer = invoke_test_file 'spec/fixtures/hook/labels.rb' do
       ClassWithLabel.new.fn_with_label
@@ -827,7 +837,7 @@ describe 'AppMap class Hooking', docker: false do
       entry = cm[1][:children][0][:children][0][:children][0]
       # Sanity check, make sure we got the right one
       expect(entry[:name]).to eq('secure_compare')
-      expect(entry[:labels]).to eq(%w[security crypto])
+      expect(entry[:labels]).to eq(%w[provider.secure_compare])
     end
   end
 

--- a/spec/record_sql_rails_pg_spec.rb
+++ b/spec/record_sql_rails_pg_spec.rb
@@ -5,7 +5,7 @@ describe 'SQL events' do
     around(:each) do |example|
       FileUtils.rm_rf tmpdir
       FileUtils.mkdir_p tmpdir
-      cmd = "docker-compose run --rm -e ORM_MODULE=#{orm_module} -e APPMAP=true -v #{File.absolute_path tmpdir}:/app/tmp app ./bin/rspec spec/controllers/users_controller_api_spec.rb:#{test_line_number}"
+      cmd = "docker-compose run --rm -e ORM_MODULE=#{orm_module} -e RAILS_ENV=test -e APPMAP=true -v #{File.absolute_path tmpdir}:/app/tmp app ./bin/rspec spec/controllers/users_controller_api_spec.rb:#{test_line_number}"
       run_cmd cmd, chdir: fixture_dir
 
       example.run

--- a/spec/rspec_feature_metadata_spec.rb
+++ b/spec/rspec_feature_metadata_spec.rb
@@ -7,7 +7,7 @@ describe 'RSpec feature and feature group metadata' do
     around(:each) do |example|
       FileUtils.rm_rf tmpdir
       FileUtils.mkdir_p tmpdir
-      cmd = "docker-compose run --rm -e APPMAP=true -v #{File.absolute_path(tmpdir).shellescape}:/app/tmp app ./bin/rspec spec/models/user_spec.rb"
+      cmd = "docker-compose run --rm -e RAILS_ENV=test -e APPMAP=true -v #{File.absolute_path(tmpdir).shellescape}:/app/tmp app ./bin/rspec spec/models/user_spec.rb"
       run_cmd cmd, chdir: fixture_dir
 
       example.run


### PR DESCRIPTION
Add global `exclude` list to *appmap.yml* which can be used to
definitively exclude specific classes and methods.

Adjust some label names to match `provider.*`, `format.*`.

Don't record OpenSSL digest method. It's very noisy in the web stack and
doesn't indicate cryptography.