### PR TITLE
Hook code anywhere in gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.41.2
+
+* Don't rely on `gemspec.source_paths` to list all the source locations in a gem. Hook any code that's loaded
+  from inside the `gem_dir`.
+
 # v0.41.1
 
 * Make best effort to ensure that class name is not `null` in the appmap.json.

--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -57,8 +57,12 @@ module AppMap
     # Methods that should always be hooked, with their containing
     # package and labels that should be applied to them.
     HOOKED_METHODS = {
-      'ActiveSupport::SecurityUtils' => Hook.new(:secure_compare, Package.build_from_path('active_support', package_name: 'active_support', labels: %w[provider.secure_compare])),
-      'ActionView::Renderer' => Hook.new(:render, Package.build_from_path('action_view', package_name: 'action_view', labels: %w[mvc.view]))
+      'ActiveSupport::SecurityUtils' => Hook.new(:secure_compare, Package.build_from_path('active_support', labels: %w[provider.secure_compare])),
+      'ActionView::Renderer' => Hook.new(:render, Package.build_from_path('action_view', labels: %w[mvc.view])),
+      'ActionDispatch::Cookies::CookieJar' => Hook.new(%i[[]= clear update delete recycle], Package.build_from_path('action_pack', labels: %w[provider.http.cookie])),
+      'ActionDispatch::Cookies::EncryptedCookieJar' => Hook.new(%i[[]=], Package.build_from_path('action_pack', labels: %w[provider.http.cookie crypto])),
+      'CanCan::ControllerAdditions' => Hook.new(%i[authorize! can? cannot?], Package.build_from_path('cancancan', labels: %w[provider.authorization])),
+      'CanCan::Ability' => Hook.new(%i[authorize!], Package.build_from_path('cancancan', labels: %w[provider.authorization])),
     }.freeze
 
     BUILTIN_METHODS = {

--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -20,20 +20,16 @@ module AppMap
             warn "WARNING: #{gem} cannot be AppMapped because it is a dependency of the appmap gem"
             return
           end
-          gem_paths(gem).map do |gem_path|
-            Package.new(gem_path, gem, package_name, exclude, labels, shallow)
-          end
+          Package.new(gem_path(gem), gem, package_name, exclude, labels, shallow)
         end
 
         private_class_method :new
 
         protected
 
-        def gem_paths(gem)
+        def gem_path(gem)
           gemspec = Gem.loaded_specs[gem] or raise "Gem #{gem.inspect} not found"
-          gemspec.source_paths.map do |path|
-            File.join(gemspec.gem_dir, path)
-          end
+          gemspec.gem_dir
         end
       end
 
@@ -75,7 +71,7 @@ module AppMap
       'Net::SMTP' => Hook.new(:send, Package.build_from_path('net/smtp', package_name: 'net/smtp', labels: %w[protocol.smtp protocol.email io])),
       'Net::POP3' => Hook.new(:mails, Package.build_from_path('net/pop3', package_name: 'net/pop', labels: %w[protocol.pop protocol.email io])),
       'Net::IMAP' => Hook.new(:send_command, Package.build_from_path('net/imap', package_name: 'net/imap', labels: %w[protocol.imap protocol.email io])),
-      'Marshal' => Hook.new(%i[dump load], Package.build_from_path('marshal', labels: %w[format.marshal provider.serialization marshal])),
+      'Marshal' => Hook.new(%i[dump load], Package.build_from_path('marshal', labels: %w[format.marshal provider.serialization])),
       'Psych' => Hook.new(%i[dump dump_stream load load_stream parse parse_stream], Package.build_from_path('yaml', package_name: 'psych', labels: %w[format.yaml provider.serialization])),
       'JSON::Ext::Parser' => Hook.new(:parse, Package.build_from_path('json', package_name: 'json', labels: %w[format.json provider.serialization])),
       'JSON::Ext::Generator::State' => Hook.new(:generate, Package.build_from_path('json', package_name: 'json', labels: %w[format.json provider.serialization])),
@@ -109,9 +105,9 @@ module AppMap
             shallow = true if shallow.nil?
             Package.build_from_gem(gem, exclude: package['exclude'] || [], shallow: shallow)
           else
-            [ Package.build_from_path(path, exclude: package['exclude'] || [], shallow: package['shallow']) ]
+            Package.build_from_path(path, exclude: package['exclude'] || [], shallow: package['shallow'])
           end
-        end.flatten.compact
+        end.compact
         Config.new config_data['name'], packages, config_data['exclude'] || []
       end
     end

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -35,7 +35,7 @@ module AppMap
                 else
                   "#{hook_method.name} (class resolution deferred)"
                 end
-          warn "AppMap: Hooking " + msg
+          warn "AppMap: Hooking #{msg} at line #{(hook_method.source_location || []).join(':')}"
         end
 
         defined_class = @defined_class

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.41.1'
+  VERSION = '0.41.2'
 
   APPMAP_FORMAT_VERSION = '1.4'
 end

--- a/spec/fixtures/rails5_users_app/docker-compose.yml
+++ b/spec/fixtures/rails5_users_app/docker-compose.yml
@@ -19,6 +19,9 @@ services:
     environment:
       RAILS_ENV:
       ORM_MODULE:
+      PGHOST: pg
+      PGPORT: '5432'
+      DATABASE_URL: postgres://postgres@pg
       APPMAP:
     volumes:
     - .:/src/app

--- a/spec/fixtures/rails6_users_app/docker-compose.yml
+++ b/spec/fixtures/rails6_users_app/docker-compose.yml
@@ -19,6 +19,9 @@ services:
     environment:
       RAILS_ENV:
       ORM_MODULE:
+      PGHOST: pg
+      PGPORT: '5432'
+      DATABASE_URL: postgres://postgres@pg
       APPMAP:
     volumes:
     - .:/src/app


### PR DESCRIPTION
Don't rely on `gemspec.source_paths` to list all the source locations in a gem. Hook any code that's loaded
  from inside the `gem_dir`.
