### PR TITLE
Enhance HTTP server request recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # v0.43.0
 
-* **Experimental** Record `name` and `class` of each entry in Hash-like parameters, messages, and return values.
-* **Experimental** Record most headers in HTTP server request and response.
+* Record `name` and `class` of each entry in Hash-like parameters, messages, and return values.
+* Record client-sent headers in HTTP server request and response.
+* Record HTTP server request `mime_type`.
+* Record HTTP server request `authorization`.
 
 # v0.42.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.43.0
+
+* **Experimental** Record `name` and `class` of each entry in Hash-like parameters, messages, and return values.
+* **Experimental** Record most headers in HTTP server request and response.
+
 # v0.42.1
 
 * Add missing require `set`.

--- a/README.md
+++ b/README.md
@@ -395,11 +395,14 @@ $ docker-compose run --rm app ./create_app
 Now you can start a development container.
 
 ```sh-session
-$ docker-compose run --rm -v $PWD/../../..:/src/appmap-ruby app bash
+$ docker-compose run --rm -v $PWD:/app -v $PWD/../../..:/src/appmap-ruby app bash
 Starting rails_users_app_pg_1 ... done
-root@6fab5f89125f:/app# cd /src/app
+root@6fab5f89125f:/app# cd /src/appmap-ruby
+root@6fab5f89125f:/src/appmap-ruby# rm ext/appmap/*.so ext/appmap/*.o
+root@6fab5f89125f:/src/appmap-ruby# bundle exec rake compile
+root@6fab5f89125f:/src/appmap-ruby# cd /src/app
 root@6fab5f89125f:/src/app# bundle config local.appmap /src/appmap-ruby
-root@6fab5f89125f:/src/app# bundle update appmap
+root@6fab5f89125f:/src/app# bundle
 ```
 
 At this point, the bundle is built with the `appmap` gem located  in `/src/appmap`, which is volume-mounted from the host.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ $ docker-compose run --rm -v $PWD:/app -v $PWD/../../..:/src/appmap-ruby app bas
 Starting rails_users_app_pg_1 ... done
 root@6fab5f89125f:/app# cd /src/appmap-ruby
 root@6fab5f89125f:/src/appmap-ruby# rm ext/appmap/*.so ext/appmap/*.o
+root@6fab5f89125f:/src/appmap-ruby# bundle
 root@6fab5f89125f:/src/appmap-ruby# bundle exec rake compile
 root@6fab5f89125f:/src/appmap-ruby# cd /src/app
 root@6fab5f89125f:/src/app# bundle config local.appmap /src/appmap-ruby
@@ -417,4 +418,3 @@ Configuring AppMap from path appmap.yml
 Finished in 0.07357 seconds (files took 2.1 seconds to load)
 4 examples, 0 failures
 ```
-

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ The fixture apps in `test/fixtures` are plain Ruby projects that exercise the ba
 
 ### `spec/fixtures`
 
-The fixture apps in `spec/fixtures` are simple Rack, Rails4, and Rails5 apps.
+The fixture apps in `spec/fixtures` are simple Rack, Rails5, and Rails6 apps.
 You can use them to interactively develop and test the recording features of the `appmap` gem.
 These fixture apps are more sophisticated than `test/fixtures`, because they include additional 
 resources such as a PostgreSQL database.

--- a/lib/appmap/event.rb
+++ b/lib/appmap/event.rb
@@ -36,6 +36,18 @@ module AppMap
           (value_string||'')[0...LIMIT].encode('utf-8', invalid: :replace, undef: :replace, replace: '_')
         end
 
+        def object_properties(hash_like)
+          hash = hash_like.to_h
+          hash.keys.map do |key|
+            {
+              name: key,
+              class: hash[key].class.name,
+            }
+          end
+        rescue
+          nil
+        end
+
         protected
 
         # Heuristic for dynamically defined class whose name can be nil
@@ -78,6 +90,12 @@ module AppMap
             last_resort_string.call
           end
         end
+      end
+
+      protected
+
+      def object_properties(hash_like)
+        self.class.object_properties(hash_like)
       end
     end
 

--- a/lib/appmap/rails/request_handler.rb
+++ b/lib/appmap/rails/request_handler.rb
@@ -6,10 +6,13 @@ require 'appmap/hook'
 module AppMap
   module Rails
     module RequestHandler
+      # Host and User-Agent will just introduce needless variation.
+      # Content-Type and Authorization get their own fields in the request.
       IGNORE_HEADERS = %w[host user_agent content_type authorization].map(&:upcase).map {|h| "HTTP_#{h}"}.freeze
 
       class << self
         def selected_headers(env)
+          # Rack prepends HTTP_ to all client-sent headers.
           matching_headers = env
             .select { |k,v| k.start_with? 'HTTP_'}
             .reject { |k,v| IGNORE_HEADERS.member?(k) }

--- a/lib/appmap/rails/request_handler.rb
+++ b/lib/appmap/rails/request_handler.rb
@@ -6,15 +6,34 @@ require 'appmap/hook'
 module AppMap
   module Rails
     module RequestHandler
+      IGNORE_HEADERS = Set.new(%w[CONTENT_LENGTH HTTPS HTTP_COOKIE HTTP_HOST HTTP_USER_AGENT PATH_INFO QUERY_STRING REMOTE_ADDR REQUEST_METHOD SCRIPT_NAME SERVER_NAME SERVER_PORT]).freeze
+
+      class << self
+        def selected_headers(headers)
+          matching_headers = headers
+            .to_h
+            .keys
+            .select{ |h| !IGNORE_HEADERS.member?(h) }
+            .select{ |h| !h.index('.') } # Toss out the Rack headers
+          if matching_headers.empty?
+            nil
+          else
+            matching_headers.inject({}) { |memo,key| memo[key] = AppMap::Event::MethodEvent.display_string(headers[key]); memo }
+          end
+        end
+      end
+
       class HTTPServerRequest < AppMap::Event::MethodEvent
-        attr_accessor :normalized_path_info, :request_method, :path_info, :params
+        attr_accessor :normalized_path_info, :request_method, :path_info, :params, :mime_type, :headers
 
         def initialize(request)
           super AppMap::Event.next_id_counter, :call, Thread.current.object_id
 
-          @request_method = request.request_method
-          @normalized_path_info = normalized_path request
-          @path_info = request.path_info.split('?')[0]
+          self.request_method = request.request_method
+          self.normalized_path_info = normalized_path request
+          self.mime_type = request.headers['Content-Type']
+          self.headers = RequestHandler.selected_headers(request.headers)
+          self.path_info = request.path_info.split('?')[0]
           # ActionDispatch::Http::ParameterFilter is deprecated
           parameter_filter_cls = \
             if defined?(ActiveSupport::ParameterFilter)
@@ -22,7 +41,7 @@ module AppMap
             else
               ActionDispatch::Http::ParameterFilter
             end
-          @params = parameter_filter_cls.new(::Rails.application.config.filter_parameters).filter(request.params)
+          self.params = parameter_filter_cls.new(::Rails.application.config.filter_parameters).filter(request.params)
         end
 
         def to_h
@@ -30,7 +49,9 @@ module AppMap
             h[:http_server_request] = {
               request_method: request_method,
               path_info: path_info,
-              normalized_path_info: normalized_path_info
+              mime_type: mime_type,
+              normalized_path_info: normalized_path_info,
+              headers: headers
             }.compact
 
             h[:message] = params.keys.map do |key|
@@ -39,8 +60,11 @@ module AppMap
                 name: key,
                 class: val.class.name,
                 value: self.class.display_string(val),
-                object_id: val.__id__
-              }
+                object_id: val.__id__,
+              }.tap do |message|
+                properties = object_properties(val)
+                message[:properties] = properties if properties
+              end
             end
           end
         end
@@ -59,7 +83,7 @@ module AppMap
       end
 
       class HTTPServerResponse < AppMap::Event::MethodReturnIgnoreValue
-        attr_accessor :status, :mime_type
+        attr_accessor :status, :mime_type, :headers
 
         def initialize(response, parent_id, elapsed)
           super AppMap::Event.next_id_counter, :return, Thread.current.object_id
@@ -68,13 +92,15 @@ module AppMap
           self.mime_type = response.headers['Content-Type']
           self.parent_id = parent_id
           self.elapsed = elapsed
+          self.headers = RequestHandler.selected_headers(response.headers)
         end
 
         def to_h
           super.tap do |h|
             h[:http_server_response] = {
               status: status,
-              mime_type: mime_type
+              mime_type: mime_type,
+              headers: headers
             }.compact
           end
         end

--- a/lib/appmap/rails/request_handler.rb
+++ b/lib/appmap/rails/request_handler.rb
@@ -8,11 +8,26 @@ module AppMap
     module RequestHandler
       MATCH_HEADERS = [
         %r{^access_control_},
+        %r{^cache_control_},
+        %r{^cross_origin_},
         %r{^cookie$},
+        %r{^digest$},
+        %r{^etag$},
+        %r{^expect$},
+        %r{^expires$},
+        %r{^if_},
+        %r{^last_modified$},
+        %r{^location$},
         %r{^set_cookie$},
         %r{^origin$},
         %r{^referer$},
         %r{^referrer_$},
+        %r{^sec_$},
+        %r{^upgrade$},
+        %r{^vary$},
+        %r{^via$},
+        %r{^want_digest$},
+        %r{^www_authenticate$},
         %r{^x_},
       ]
 

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.42.1'
+  VERSION = '0.43.0'
 
   APPMAP_FORMAT_VERSION = '1.4'
 end

--- a/spec/abstract_controller_base_spec.rb
+++ b/spec/abstract_controller_base_spec.rb
@@ -37,6 +37,7 @@ describe 'AbstractControllerBase' do
               hash_including(
                 'http_server_request' => hash_including(
                   'request_method' => 'POST',
+                  'normalized_path_info' => '/api/users(.:format)',
                   'path_info' => '/api/users'
                 ),
                 'message' => include(
@@ -75,7 +76,7 @@ describe 'AbstractControllerBase' do
               'defined_class' => 'Api::UsersController',
               'method_id' => 'build_user',
               'path' => 'app/controllers/api/users_controller.rb',
-              'lineno' => 23,
+              'lineno' => Integer,
               'static' => false,
               'parameters' => include(
                 'name' => 'params',

--- a/spec/abstract_controller_base_spec.rb
+++ b/spec/abstract_controller_base_spec.rb
@@ -63,6 +63,11 @@ describe 'AbstractControllerBase' do
             )
           end
 
+          context 'with an object-style message' do
+            # TODO
+            it 'message properties are recorded in the appmap'
+          end
+
           it 'properly captures method parameters in the appmap' do
             expect(events).to include hash_including(
               'event' => 'call',

--- a/spec/abstract_controller_base_spec.rb
+++ b/spec/abstract_controller_base_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_spec_helper'
 
-describe 'AbstractControllerBase' do
+describe 'Rails' do
   %w[5 6].each do |rails_major_version| # rubocop:disable Metrics/BlockLength
-    context "in Rails #{rails_major_version}" do
-      include_context 'Rails app pg database', "spec/fixtures/rails#{rails_major_version}_users_app"
+    context "#{rails_major_version}" do
+      include_context 'Rails app pg database', "spec/fixtures/rails#{rails_major_version}_users_app" unless use_existing_data?
+
       def run_spec(spec_name)
-        FileUtils.rm_rf tmpdir
-        FileUtils.mkdir_p tmpdir
         cmd = <<~CMD.gsub "\n", ' '
           docker-compose run --rm -e RAILS_ENV=test -e APPMAP=true
           -v #{File.absolute_path tmpdir}:/app/tmp app ./bin/rspec #{spec_name}
@@ -18,12 +17,20 @@ describe 'AbstractControllerBase' do
         'tmp/spec/AbstractControllerBase'
       end
 
+      unless use_existing_data?
+        before(:all) do
+          FileUtils.rm_rf tmpdir
+          FileUtils.mkdir_p tmpdir
+          run_spec 'spec/controllers/users_controller_spec.rb'
+          run_spec 'spec/controllers/users_controller_api_spec.rb'
+        end
+      end
+
       let(:appmap) { JSON.parse File.read File.join tmpdir, 'appmap/rspec', appmap_json_file }
       let(:events) { appmap['events'] }
 
-      describe 'testing with rspec' do
-        describe 'creating a user' do
-          before(:all) { run_spec 'spec/controllers/users_controller_api_spec.rb:8' }
+      describe 'an API route' do
+        describe 'creating an object' do
           let(:appmap_json_file) do
             'Api_UsersController_POST_api_users_with_required_parameters_creates_a_user.appmap.json'
           end
@@ -32,7 +39,7 @@ describe 'AbstractControllerBase' do
             expect(File).to exist(File.join(tmpdir, 'appmap/rspec/Inventory.appmap.json'))
           end
 
-          it 'message fields are recorded in the appmap' do
+          it 'http_server_request is recorded in the appmap' do
             expect(events).to include(
               hash_including(
                 'http_server_request' => hash_including(
@@ -54,19 +61,19 @@ describe 'AbstractControllerBase' do
                     'object_id' => Integer
                   )
                 )
-              ),
-              hash_including(
-                'http_server_response' => {
-                  'status' => 201,
-                  'mime_type' => 'application/json; charset=utf-8'
-                }
               )
             )
           end
 
-          context 'with an object-style message' do
-            # TODO
-            it 'message properties are recorded in the appmap'
+          it 'http_server_response is recorded in the appmap' do
+            expect(events).to include(
+              hash_including(
+                'http_server_response' => hash_including(
+                  'status' => 201,
+                  'mime_type' => 'application/json; charset=utf-8'
+                )
+              )
+            )
           end
 
           it 'properly captures method parameters in the appmap' do
@@ -99,10 +106,47 @@ describe 'AbstractControllerBase' do
               'elapsed' => Numeric
             )
           end
+
+          context 'with an object-style message' do
+            let(:appmap_json_file) { 'Api_UsersController_POST_api_users_with_required_parameters_with_object-style_parameters_creates_a_user.appmap.json' }
+
+            it 'message properties are recorded in the appmap' do
+              expect(events).to include(
+                hash_including(
+                  'message' => include(
+                    hash_including(
+                      'name' => 'user',
+                      'properties' => [
+                        { 'name' => 'login', 'class' => 'String' },
+                        { 'name' => 'password', 'class' => 'String' }
+                      ]
+                    )
+                  )
+                )
+              )    
+            end
+          end
         end
 
-        describe 'showing a user' do
-          before(:all) { run_spec 'spec/controllers/users_controller_spec.rb:22' }
+        describe 'listing objects' do
+          context 'with a custom header' do
+            let(:appmap_json_file) { 'Api_UsersController_GET_api_users_with_a_custom_header_lists_the_users.appmap.json' }
+
+            it 'custom header is recorded in the appmap' do
+              expect(events).to include(
+                hash_including(
+                  'http_server_request' => hash_including(
+                    'headers' => hash_including('X-Sandwich' => 'turkey')
+                  )
+                )
+              )
+            end
+          end
+        end
+      end
+
+      describe 'a UI route' do
+        describe 'rendering a page' do
           let(:appmap_json_file) do
             'UsersController_GET_users_login_shows_the_user.appmap.json'
           end
@@ -118,11 +162,6 @@ describe 'AbstractControllerBase' do
               )
             )
           end
-        end
-
-        describe 'listing users' do
-          before(:all) { run_spec 'spec/controllers/users_controller_spec.rb:11' }
-          let(:appmap_json_file) { 'UsersController_GET_users_lists_the_users.appmap.json' }
 
           it 'records and labels view rendering' do
             expect(events).to include hash_including(
@@ -134,7 +173,7 @@ describe 'AbstractControllerBase' do
               'lineno' => Integer,
               'static' => false
             )
-
+  
             expect(appmap['classMap']).to include hash_including(
               'name' => 'action_view',
               'children' => include(hash_including(
@@ -148,7 +187,7 @@ describe 'AbstractControllerBase' do
                 ))
               ))
             )
-          end
+          end  
         end
       end
     end

--- a/spec/fixtures/rails5_users_app/Gemfile
+++ b/spec/fixtures/rails5_users_app/Gemfile
@@ -44,6 +44,8 @@ group :development, :test do
 end
 
 group :test do
+  # Require only one of these.
+  # 'database_cleaner' requries 'database_cleaner-active_record', so don't require it.
   gem 'database_cleaner-active_record', require: false
   gem 'database_cleaner-sequel', require: false
 end

--- a/spec/fixtures/rails5_users_app/Gemfile
+++ b/spec/fixtures/rails5_users_app/Gemfile
@@ -39,11 +39,13 @@ group :development, :test do
   gem 'appmap', appmap_options
   gem 'cucumber-rails', require: false
   gem 'rspec-rails'
-  # Required for Sequel, since without ActiveRecord, the Rails transactional fixture support
-  # isn't activated.
-  gem 'database_cleaner'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'
+end
+
+group :test do
+  gem 'database_cleaner-active_record', require: false
+  gem 'database_cleaner-sequel', require: false
 end
 
 group :development do

--- a/spec/fixtures/rails5_users_app/app/controllers/api/users_controller.rb
+++ b/spec/fixtures/rails5_users_app/app/controllers/api/users_controller.rb
@@ -6,6 +6,8 @@ module Api
     end
 
     def create
+      params = self.params.key?(:user) ? self.params[:user] : self.params
+      
       @user = build_user(params.slice(:login).to_unsafe_h)
       unless @user.valid?
         error = {

--- a/spec/fixtures/rails5_users_app/app/controllers/users_controller.rb
+++ b/spec/fixtures/rails5_users_app/app/controllers/users_controller.rb
@@ -4,7 +4,15 @@ class UsersController < ApplicationController
   end
 
   def show
-    if (@user = User[login: params[:id]])
+    find_user = lambda do |id|
+      if User.respond_to?(:[])
+        User[login: id]
+      else
+        User.find_by_login!(id)
+      end
+    end
+
+    if (@user = find_user.(params[:id]))
       render plain: @user
     else
       render plain: 'Not found', status: 404

--- a/spec/fixtures/rails5_users_app/config/application.rb
+++ b/spec/fixtures/rails5_users_app/config/application.rb
@@ -15,8 +15,10 @@ case orm_module
 when 'sequel'
   require 'sequel-rails'
   require 'sequel_secure_password'
+  require 'database_cleaner-sequel' if Rails.env.test?
 when 'activerecord'
   require 'active_record/railtie'
+  require 'database_cleaner-active_record' if Rails.env.test?
 end
 
 require 'appmap/railtie' if defined?(AppMap)

--- a/spec/fixtures/rails5_users_app/create_app
+++ b/spec/fixtures/rails5_users_app/create_app
@@ -16,10 +16,16 @@ if [[ $? != 0 ]]; then
    exit 1
 fi
 
+# Required for migrations
+export ORM_MODULE=sequel
+
+set +e
+psql -h pg -U postgres -c "drop database if exists app_development"
+psql -h pg -U postgres -c "drop database if exists app_test"
+set -e
+
 psql -h pg -U postgres -c "create database app_development"
 psql -h pg -U postgres -c "create database app_test"
-
-set -e
 
 RAILS_ENV=development ./bin/rake db:migrate
 RAILS_ENV=test ./bin/rake db:migrate

--- a/spec/fixtures/rails5_users_app/spec/controllers/users_controller_api_spec.rb
+++ b/spec/fixtures/rails5_users_app/spec/controllers/users_controller_api_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::UsersController, type: :controller do
     end
     describe 'with a custom header' do
       it 'lists the users' do
-        set_header 'X-Sandwich', 'turkey'
+        request.headers['X-Sandwich'] = 'turkey'
         get :index, params: {}
         expect(response.status).to eq(200)
       end

--- a/spec/fixtures/rails5_users_app/spec/controllers/users_controller_api_spec.rb
+++ b/spec/fixtures/rails5_users_app/spec/controllers/users_controller_api_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Api::UsersController, type: :controller do
         post :create, params: { login: 'alice', password: 'foobar' }
         expect(response.status).to eq(201)
       end
+      describe 'with object-style parameters' do
+        it 'creates a user' do
+          post :create, params: { user: { login: 'alice', password: 'foobar' } }
+          expect(response.status).to eq(201)
+        end
+      end
     end
     describe 'with a missing parameter' do
       it 'reports error 422' do
@@ -24,6 +30,13 @@ RSpec.describe Api::UsersController, type: :controller do
       get :index, params: {}
       users = JSON.parse(response.body)
       expect(users.map { |r| r['login'] }).to include('alice')
+    end
+    describe 'with a custom header' do
+      it 'lists the users' do
+        set_header 'X-Sandwich', 'turkey'
+        get :index, params: {}
+        expect(response.status).to eq(200)
+      end
     end
   end
 end

--- a/spec/fixtures/rails5_users_app/spec/controllers/users_controller_spec.rb
+++ b/spec/fixtures/rails5_users_app/spec/controllers/users_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rack/test'
 RSpec.describe UsersController, type: :controller do
   render_views
 
-  describe 'GET /users', feature: 'Show all users' do
+  describe 'GET /users' do
     before do
       User.create login: 'alice'
     end
@@ -14,7 +14,7 @@ RSpec.describe UsersController, type: :controller do
     end
   end
 
-  describe 'GET /users/:login', feature: 'Show a user' do
+  describe 'GET /users/:login' do
     before do
       User.create login: 'alice'
     end

--- a/spec/fixtures/rails5_users_app/spec/rails_helper.rb
+++ b/spec/fixtures/rails5_users_app/spec/rails_helper.rb
@@ -45,7 +45,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-
   DatabaseCleaner.allow_remote_database_url = true
   
   config.before(:suite) do
@@ -54,13 +53,8 @@ RSpec.configure do |config|
   end
 
   config.around :each do |example|
-    # Enable the use of 'return' from a guard
-    -> {
-      return example.run unless %i[model controller].member?(example.metadata[:type])
-
-      DatabaseCleaner.cleaning do
-        example.run
-      end
-    }.call
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 end

--- a/spec/fixtures/rails6_users_app/Gemfile
+++ b/spec/fixtures/rails6_users_app/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6'
 
 gem 'haml-rails'
@@ -40,11 +39,13 @@ group :development, :test do
   gem 'appmap', appmap_options
   gem 'cucumber-rails', require: false
   gem 'rspec-rails'
-  # Required for Sequel, since without ActiveRecord, the Rails transactional fixture support
-  # isn't activated.
-  gem 'database_cleaner'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'
+end
+
+group :test do
+  gem 'database_cleaner-active_record', require: false
+  gem 'database_cleaner-sequel', require: false
 end
 
 group :development do

--- a/spec/fixtures/rails6_users_app/app/controllers/api/users_controller.rb
+++ b/spec/fixtures/rails6_users_app/app/controllers/api/users_controller.rb
@@ -6,6 +6,7 @@ module Api
     end
 
     def create
+      params = self.params.key?(:user) ? self.params[:user] : self.params
       @user = build_user(params.slice(:login).to_unsafe_h)
       unless @user.valid?
         error = {

--- a/spec/fixtures/rails6_users_app/app/controllers/users_controller.rb
+++ b/spec/fixtures/rails6_users_app/app/controllers/users_controller.rb
@@ -4,7 +4,15 @@ class UsersController < ApplicationController
   end
 
   def show
-    if (@user = User[login: params[:id]])
+    find_user = lambda do |id|
+      if User.respond_to?(:[])
+        User[login: id]
+      else
+        User.find_by_login!(id)
+      end
+    end
+
+    if (@user = find_user.(params[:id]))
       render plain: @user
     else
       render plain: 'Not found', status: 404

--- a/spec/fixtures/rails6_users_app/config/application.rb
+++ b/spec/fixtures/rails6_users_app/config/application.rb
@@ -15,8 +15,10 @@ case orm_module
 when 'sequel'
   require 'sequel-rails'
   require 'sequel_secure_password'
+  require 'database_cleaner-sequel' if Rails.env.test?
 when 'activerecord'
   require 'active_record/railtie'
+  require 'database_cleaner-active_record' if Rails.env.test?
 end
 
 require 'appmap/railtie' if defined?(AppMap)

--- a/spec/fixtures/rails6_users_app/create_app
+++ b/spec/fixtures/rails6_users_app/create_app
@@ -16,10 +16,16 @@ if [[ $? != 0 ]]; then
    exit 1
 fi
 
+# Required for migrations
+export ORM_MODULE=sequel
+
+set +e
+psql -h pg -U postgres -c "drop database if exists app_development"
+psql -h pg -U postgres -c "drop database if exists app_test"
+set -e
+
 psql -h pg -U postgres -c "create database app_development"
 psql -h pg -U postgres -c "create database app_test"
-
-set -e
 
 RAILS_ENV=development ./bin/rake db:migrate
 RAILS_ENV=test ./bin/rake db:migrate

--- a/spec/fixtures/rails6_users_app/spec/controllers/users_controller_api_spec.rb
+++ b/spec/fixtures/rails6_users_app/spec/controllers/users_controller_api_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::UsersController, type: :controller do
     end
     describe 'with a custom header' do
       it 'lists the users' do
-        set_header 'X-Sandwich', 'turkey'
+        request.headers['X-Sandwich'] = 'turkey'
         get :index, params: {}
         expect(response.status).to eq(200)
       end

--- a/spec/fixtures/rails6_users_app/spec/controllers/users_controller_api_spec.rb
+++ b/spec/fixtures/rails6_users_app/spec/controllers/users_controller_api_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Api::UsersController, type: :controller do
         post :create, params: { login: 'alice', password: 'foobar' }
         expect(response.status).to eq(201)
       end
+      describe 'with object-style parameters' do
+        it 'creates a user' do
+          post :create, params: { user: { login: 'alice', password: 'foobar' } }
+          expect(response.status).to eq(201)
+        end
+      end
     end
     describe 'with a missing parameter' do
       it 'reports error 422' do
@@ -24,6 +30,13 @@ RSpec.describe Api::UsersController, type: :controller do
       get :index, params: {}
       users = JSON.parse(response.body)
       expect(users.map { |r| r['login'] }).to include('alice')
+    end
+    describe 'with a custom header' do
+      it 'lists the users' do
+        set_header 'X-Sandwich', 'turkey'
+        get :index, params: {}
+        expect(response.status).to eq(200)
+      end
     end
   end
 end

--- a/spec/fixtures/rails6_users_app/spec/controllers/users_controller_spec.rb
+++ b/spec/fixtures/rails6_users_app/spec/controllers/users_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rack/test'
 RSpec.describe UsersController, type: :controller do
   render_views
 
-  describe 'GET /users', feature: 'Show all users' do
+  describe 'GET /users' do
     before do
       User.create login: 'alice'
     end
@@ -14,7 +14,7 @@ RSpec.describe UsersController, type: :controller do
     end
   end
 
-  describe 'GET /users/:login', feature: 'Show a user' do
+  describe 'GET /users/:login' do
     before do
       User.create login: 'alice'
     end

--- a/spec/fixtures/rails6_users_app/spec/rails_helper.rb
+++ b/spec/fixtures/rails6_users_app/spec/rails_helper.rb
@@ -45,7 +45,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-
   DatabaseCleaner.allow_remote_database_url = true
   
   config.before(:suite) do
@@ -54,13 +53,8 @@ RSpec.configure do |config|
   end
 
   config.around :each do |example|
-    # Enable the use of 'return' from a guard
-    -> {
-      return example.run unless %i[model controller].member?(example.metadata[:type])
-
-      DatabaseCleaner.cleaning do
-        example.run
-      end
-    }.call
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 end

--- a/spec/record_sql_rails_pg_spec.rb
+++ b/spec/record_sql_rails_pg_spec.rb
@@ -61,7 +61,7 @@ describe 'SQL events' do
       end
 
       context 'while listing records' do
-        let(:test_line_number) { 23 }
+        let(:test_line_number) { 29 }
         let(:appmap_json) { File.join(tmpdir, 'appmap/rspec/Api_UsersController_GET_api_users_lists_the_users.appmap.json') }
 
         context 'using Sequel ORM' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,3 +14,7 @@ require 'appmap'
 RSpec.configure do |config|
   config.example_status_persistence_file_path = "tmp/rspec_failed_examples.txt"
 end
+
+def use_existing_data?
+  ENV['USE_EXISTING_DATA'] == 'true'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = "tmp/rspec_failed_examples.txt"
 end
 
+# Re-run the Rails specs without re-generating the data. This is useful for efficiently enhancing and
+# debugging the test itself.
 def use_existing_data?
   ENV['USE_EXISTING_DATA'] == 'true'
 end


### PR DESCRIPTION
Adds more useful information to `http_server_request` and `_response`. This enhances our ability to generate Swagger.

* Record `name` and `class` of each entry in Hash-like parameters, messages, and return values.

Example: 
```ruby
                      'name' => 'user',
                      'properties' => [
                        { 'name' => 'login', 'class' => 'String' },
                        { 'name' => 'password', 'class' => 'String' }
                      ]
```

* Record client-sent headers in HTTP server request and response.

Example:
```ruby
                  'http_server_request' => hash_including(
                    'headers' => hash_including('X-Sandwich' => 'turkey')
                  )
```

* Record HTTP server request `mime_type` (client `Content-Type` header).
* Record HTTP server request `authorization` (client `Authorization` header).

Fix specs by including only `sequel` or `active_record` database cleaner.

