### PR TITLE
feat(ci): semantic-release and publication to rubygems

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,11 @@
+plugins:
+  - '@semantic-release/commit-analyzer'
+  - '@semantic-release/release-notes-generator'
+  - '@semantic-release/changelog'
+  - 'semantic-release-rubygem'
+  - - '@semantic-release/git'
+    - assets:
+        - CHANGELOG.md
+        - appmap.gemspec
+        - lib/appmap/version.rb
+  - '@semantic-release/github'

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,28 @@ before_install:
   # Load cached docker images
   - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
 
+ 
+# GEM_ALTERNATIVE_NAME only needed for deployment 
 jobs:
   include:
   - stage: test
     script:
     - mkdir tmp
-    - bundle exec rake test
+    - GEM_ALTERNATIVE_NAME='' bundle exec rake test
+
+    
+before_deploy:
+  - |
+    nvm install --lts \
+      && nvm use --lts \
+      && npm i -g \
+        semantic-release \
+        @semantic-release/git \
+        @semantic-release/changelog \
+        semantic-release-rubygem
+
+deploy:
+  - provider: script
+    script: ./release.sh
+    on:
+      branch: master

--- a/README_CI.md
+++ b/README_CI.md
@@ -1,0 +1,22 @@
+# Configuration variables:
+
+* `GH_TOKEN`: used by `semantic-release` to push changes to Github and manage releases
+* `GEM_HOST_API_KEY`: rubygems API key
+* `GEM_ALTERNATIVE_NAME` (optional): used for testing of CI flows, 
+to avoid publication of test releases under official package name
+
+# Release command
+
+`./release.sh` 
+
+Bash wrapper script is used merely as a launcher of `semantic-release` 
+with extra logic to explicitly determine git url from `TRAVIS_REPO_SLUG` \
+variable if its defined (otherwise git url is taken from `package.json`, 
+which breaks CI on forked repos).
+
+# CI flow
+
+1. Test happens using current version number specified in `lib/appmap/version.rb`, then `release.sh` launches `semantic-release` to do the rest
+2. The version number is increased (including modicication of `version.rb`)
+3. Gem is published under new version number
+4. Github release is created with the new version number

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,8 @@ end
   
 def build_base_image(ruby_version)
   run_cmd "docker build" \
-         " --build-arg RUBY_VERSION=#{ruby_version} --build-arg GEM_VERSION=#{GEM_VERSION}" \
+         " --build-arg RUBY_VERSION=#{ruby_version}"    \
+         " --build-arg GEM_VERSION=#{GEM_VERSION}"      \
          " -t appmap:#{GEM_VERSION} -f Dockerfile.appmap ."
 end
   
@@ -46,7 +47,7 @@ def build_app_image(app, ruby_version)
     run_cmd( {"RUBY_VERSION" => ruby_version, "GEM_VERSION" => GEM_VERSION},
       " docker-compose build" \
       " --build-arg RUBY_VERSION=#{ruby_version}" \
-      " --build-arg GEM_VERSION=#{GEM_VERSION}")
+      " --build-arg GEM_VERSION=#{GEM_VERSION}"  ) 
   end
 end
 
@@ -138,3 +139,4 @@ task spec: %i[spec:all]
 task test: %i[spec:all minitest]
 
 task default: :test
+

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -4,8 +4,12 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'appmap/version'
 
+
+
 Gem::Specification.new do |spec|
-  spec.name          = 'appmap'
+  # ability to parameterize gem name is added intentionally, 
+  # to support the possibility of unofficial releases, e.g. during CI tests
+  spec.name          = (ENV['GEM_ALTERNATIVE_NAME'].to_s.empty? ? 'appmap' : ENV["GEM_ALTERNATIVE_NAME"] )
   spec.version       = AppMap::VERSION
   spec.authors       = ['Kevin Gilpin']
   spec.email         = ['kgilpin@gmail.com']

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# using bash wrapper as Rake blows up in `require/extentiontask` (line 10)
+
+RELEASE_FLAGS=""
+if [ ! -z "$TRAVIS_REPO_SLUG" ]; then
+    RELEASE_FLAGS="-r git+https://github.com/${TRAVIS_REPO_SLUG}.git"
+fi 
+
+if [ ! -z "$GEM_ALTERNATIVE_NAME" ]; then
+    echo "Release: GEM_ALTERNATIVE_NAME=$GEM_ALTERNATIVE_NAME"
+else
+    echo "No GEM_ALTERNATIVE_NAME is provided, releasing gem with default name ('appmap')"
+fi
+
+set -x
+exec semantic-release $RELEASE_FLAGS
+


### PR DESCRIPTION
# Summary 

1. CI deployment step is added, bringing in `semantic-release` logic 
2. As a part of automated release process, publication to rubygems happens (alternative gem names are supported for testing purposes)

# Important note

This change has impact on the `master` branch management, check semantic-release commits conventions and get prepared to Travis interventions (version increases, chore commits, github releases) 

# Configuration (environment variables)

* `GH_TOKEN`: used by `semantic-release` to push changes to Github and manage releases
* `GEM_HOST_API_KEY`: rubygems API key
* `GEM_ALTERNATIVE_NAME` (optional): used for testing of CI flows, to avoid publication of test releases under official package name


# See also:

`README_CI.md`
