### PR TITLE
ci-performance: support optional Dockerhub auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ cache:
     - $HOME/docker
 
 # https://stackoverflow.com/a/41975912
+# also it's important to stay inside Dockerhub quota of 100-200 pulls per 6 hours
+# (see https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/ )
 before_cache:
   # Save tagged docker images
   - >
@@ -29,6 +31,14 @@ before_cache:
 before_install:
   # Load cached docker images
   - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
+  # see https://blog.travis-ci.com/docker-rate-limits 
+  # and also https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/
+  # if we do not use authorized account, 
+  # the pulls-per-IP quota is shared with other Travis users
+  - >
+    if [ ! -z "$DOCKERHUB_PASSWORD" ] && [ ! -z "$DOCKERHUB_USERNAME" ]; then
+      echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin  ;
+    fi
 
  
 # GEM_ALTERNATIVE_NAME only needed for deployment 

--- a/README_CI.md
+++ b/README_CI.md
@@ -4,6 +4,13 @@
 * `GEM_HOST_API_KEY`: rubygems API key
 * `GEM_ALTERNATIVE_NAME` (optional): used for testing of CI flows, 
 to avoid publication of test releases under official package name
+* `DOCKERHUB\_USERNAME`, `DOCKERHUB_PASSWORD`: optional dockerhub credentials, 
+to avoid throttling of dockerhub anonymous pulls
+
+Note: for security reasons, it's better to use dedicated (not personal) 
+Dockerhub account, 
+and also use [access tokens](https://docs.docker.com/docker-hub/access-tokens/) 
+instead of primary password
 
 # Release command
 


### PR DESCRIPTION
If `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` are defined,
Travis performs docker login prior to running tests, in order
to avoid hitting anonymous pull quotas.

For security purposes, it's recommended to use dedicated Dockerhub account,
and access token instead of primary password.