### PR TITLE
fix: Add the proper template function hooks for Rails 6.0.7

### DIFF
--- a/lib/appmap/handler/rails/template.rb
+++ b/lib/appmap/handler/rails/template.rb
@@ -105,12 +105,18 @@ module AppMap
             # If so, populate the template path. In all cases, add a TemplateMethod so that the
             # template will be recorded in the classMap.
             def handle_return(call_event_id, elapsed, return_value, exception)
-              warn "Resolver return: #{return_value.inspect}" if LOG
-
               renderer = Array(Thread.current[TEMPLATE_RENDERER]).last
-              path = Array(return_value).first&.inspect
+              path_obj = Array(return_value).first
+              
+              warn "Resolver return: #{path_obj}" if LOG
 
-              if path
+              if path_obj
+                path = if path_obj.respond_to?(:identifier) && path_obj.inspect.index('#<')
+                  path_obj.identifier
+                else
+                  path_obj.inspect
+                end
+                path = path[Dir.pwd.length + 1..-1] if path.index(Dir.pwd) == 0
                 AppMap.tracing.record_method(TemplateMethod.new(path))
                 renderer.path ||= path if renderer
               end

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -64,7 +64,7 @@ module AppMap
         end
       end
 
-      config.builtin_methods.each do |class_name, hooks|
+      config.builtin_hooks.each do |class_name, hooks|
         Array(hooks).each do |hook|
           require hook.package.package_name if hook.package.package_name
           Array(hook.method_names).each do |method_name|
@@ -138,6 +138,8 @@ module AppMap
           # Don't try and trace the AppMap methods or there will be
           # a stack overflow in the defined hook method.
           next if %w[Marshal AppMap ActiveSupport].member?((hook_cls&.name || '').split('::')[0])
+
+          next if method_id == :call
 
           method = begin
             hook_cls.public_instance_method(method_id)

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -64,65 +64,14 @@ describe 'AppMap class Hooking', docker: false do
     expect(config.never_hook?(ExcludeTest, ExcludeTest.method(:cls_method))).to be_truthy
   end
 
-  it "handles an instance method named 'call' without issues" do
+  it "an instance method named 'call' will be ignored" do
     events_yaml = <<~YAML
-    ---
-    - :id: 1
-      :event: :call
-      :defined_class: MethodNamedCall
-      :method_id: call
-      :path: spec/fixtures/hook/method_named_call.rb
-      :lineno: 8
-      :static: false
-      :parameters:
-      - :name: :a
-        :class: Integer
-        :value: '1'
-        :kind: :req
-      - :name: :b
-        :class: Integer
-        :value: '2'
-        :kind: :req
-      - :name: :c
-        :class: Integer
-        :value: '3'
-        :kind: :req
-      - :name: :d
-        :class: Integer
-        :value: '4'
-        :kind: :req
-      - :name: :e
-        :class: Integer
-        :value: '5'
-        :kind: :req
-      :receiver:
-        :class: MethodNamedCall
-        :value: MethodNamedCall
-    - :id: 2
-      :event: :return
-      :parent_id: 1
-      :return_value:
-        :class: String
-        :value: 1 2 3 4 5
+    --- []
     YAML
 
     _, tracer = test_hook_behavior 'spec/fixtures/hook/method_named_call.rb', events_yaml do
       expect(MethodNamedCall.new.call(1, 2, 3, 4, 5)).to eq('1 2 3 4 5')
     end
-    class_map = AppMap.class_map(tracer.event_methods)
-    expect(Diffy::Diff.new(<<~CLASSMAP, YAML.dump(class_map)).to_s).to eq('')
-    ---
-    - :name: spec/fixtures/hook/method_named_call.rb
-      :type: package
-      :children:
-      - :name: MethodNamedCall
-        :type: class
-        :children:
-        - :name: call
-          :type: function
-          :location: spec/fixtures/hook/method_named_call.rb:8
-          :static: false
-    CLASSMAP
   end
 
   it 'can custom hook and label a function' do


### PR DESCRIPTION
Ignore methods named 'call'