### PR TITLE
Conditional init

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,22 +83,6 @@ If you are using Ruby on Rails, require the railtie after Rails is loaded.
 require 'appmap/railtie' if defined?(AppMap).
 ```
 
-**application.rb**
-
-Add this line to *application.rb*, to enable server recording with `APPMAP_RECORD=true`:
-
-```ruby
-module MyApp
-  class Application < Rails::Application
-    ...
-  
-    config.appmap.enabled = true if ENV['APPMAP_RECORD']
-    
-    ...
-  end
-end
-```
-
 # Configuration
 
 When you run your program, the `appmap` gem reads configuration settings from `appmap.yml`. Here's a sample configuration

--- a/lib/appmap.rb
+++ b/lib/appmap.rb
@@ -98,4 +98,4 @@ module AppMap
 end
 
 require 'appmap/railtie' if defined?(::Rails::Railtie)
-AppMap.initialize unless ENV['APPMAP_INITIALIZE'] == 'false'
+AppMap.initialize if ENV['APPMAP'] == 'true'

--- a/lib/appmap/railtie.rb
+++ b/lib/appmap/railtie.rb
@@ -3,8 +3,6 @@
 module AppMap
   # Railtie connects the AppMap recorder to Rails-specific features.
   class Railtie < ::Rails::Railtie
-    config.appmap = ActiveSupport::OrderedOptions.new
-
     # appmap.subscribe subscribes to ActiveSupport Notifications so that they can be recorded as
     # AppMap events.
     initializer 'appmap.subscribe' do |_| # params: app
@@ -15,25 +13,5 @@ module AppMap
 
       AppMap::Handler::Rails::RequestHandler::HookMethod.new.activate
     end
-
-    # appmap.trace begins recording an AppMap trace and writes it to appmap.json.
-    # This behavior is only activated if the configuration setting app.config.appmap.enabled
-    # is truthy.
-    initializer 'appmap.trace', after: 'appmap.subscribe' do |app|
-      lambda do
-        return unless app.config.appmap.enabled
-
-        require 'appmap/command/record'
-        require 'json'
-        AppMap::Command::Record.new(AppMap.configuration).perform do |version, metadata, class_map, events|
-          appmap = JSON.generate \
-            version: version,
-            metadata: metadata,
-            classMap: class_map,
-            events: events
-          File.open('appmap.json', 'w').write(appmap)
-        end
-      end.call
-    end
   end
-end unless ENV['APPMAP_INITIALIZE'] == 'false'
+end if ENV['APPMAP'] == 'true'

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -5,5 +5,5 @@ module AppMap
 
   VERSION = '0.47.1'
 
-  APPMAP_FORMAT_VERSION = '1.5.0'
+  APPMAP_FORMAT_VERSION = '1.5.1'
 end

--- a/spec/fixtures/rails5_users_app/config/application.rb
+++ b/spec/fixtures/rails5_users_app/config/application.rb
@@ -38,8 +38,6 @@ module UsersApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
-    config.appmap.enabled = true if ENV['APPMAP'] == 'true' && !Rails.env.test?
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/spec/fixtures/rails6_users_app/config/application.rb
+++ b/spec/fixtures/rails6_users_app/config/application.rb
@@ -38,8 +38,6 @@ module UsersApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
-    config.appmap.enabled = true if ENV['APPMAP'] == 'true' && !Rails.env.test?
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -4,7 +4,7 @@ describe 'AppMap tracer via Railtie' do
   include_context 'Rails app pg database', 'spec/fixtures/rails5_users_app' do 
     let(:env) { {} }
 
-    let(:cmd) { %(docker-compose run --rm -e RAILS_ENV -e APPMAP app ./bin/rails r "puts Rails.configuration.appmap.enabled.inspect") }
+    let(:cmd) { %(docker-compose run --rm -e RAILS_ENV=development -e APPMAP app ./bin/rails r "puts AppMap.instance_variable_get('@configuration').nil?") }
     let(:command_capture2) do
       require 'open3'
       Open3.capture3(env, cmd, chdir: fixture_dir).tap do |result|
@@ -23,20 +23,16 @@ describe 'AppMap tracer via Railtie' do
     let(:command_output) { command_capture2[0].strip }
     let(:command_result) { command_capture2[2] }
 
-    it 'is disabled by default' do
-      expect(command_output).to eq('nil')
+    describe 'with APPMAP=false' do
+      let(:env) { { 'APPMAP' => 'false' } }
+      it 'is disabled' do
+        expect(command_output).to eq('true')
+      end
     end
-
     describe 'with APPMAP=true' do
       let(:env) { { 'APPMAP' => 'true' } }
       it 'is enabled' do
-        expect(command_output.split("\n")).to include('true')
-      end
-      context 'and RAILS_ENV=test' do
-        let(:env) { { 'APPMAP' => 'true', 'RAILS_ENV' => 'test' } }
-        it 'is disabled' do
-          expect(command_output).to eq('nil')
-        end
+        expect(command_output).to eq('false')
       end
     end
   end


### PR DESCRIPTION
Initialization (code hooking) only proceeds if `APPMAP=true`.

Omitting `APPMAP=true` enables quick and clean startup, and normal debugging, even in test and development.