### PR TITLE
Fix bundle path and exception messages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@ vendor
 node_modules
 spec/fixtures/rails*_users_app
 spec/fixtures/rack_users_app
-

--- a/lib/appmap/event.rb
+++ b/lib/appmap/event.rb
@@ -213,7 +213,7 @@ module AppMap
                 exception_backtrace = next_exception.backtrace_locations.try(:[], 0)
                 exceptions << {
                   class: best_class_name(next_exception),
-                  message: next_exception.message,
+                  message: display_string(next_exception.message),
                   object_id: next_exception.__id__,
                   path: exception_backtrace&.path,
                   lineno: exception_backtrace&.lineno

--- a/lib/appmap/minitest.rb
+++ b/lib/appmap/minitest.rb
@@ -98,7 +98,7 @@ module AppMap
           if exception
             m[:exception] = {
               class: exception.class.name,
-              message: exception.to_s
+              message: AppMap::Event::MethodEvent.display_string(exception.to_s)
             }
           end
         end

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -183,7 +183,7 @@ module AppMap
           if exception
             m[:exception] = {
               class: exception.class.name,
-              message: exception.to_s
+              message: AppMap::Event::MethodEvent.display_string(exception.to_s)
             }
           end
         end

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bundler'
+
 module AppMap
   module Util
     class << self
@@ -94,7 +96,7 @@ module AppMap
       end
 
       def normalize_path(path)
-        if path.index(Dir.pwd) == 0
+        if path.index(Dir.pwd) == 0 && !path.index(Bundler.bundle_path.to_s)
           path[Dir.pwd.length + 1..-1]
         else
           path

--- a/spec/fixtures/hook/exception_method.rb
+++ b/spec/fixtures/hook/exception_method.rb
@@ -53,3 +53,9 @@ class ToSRaises
     "hello"
   end
 end
+
+class ExceptionMethod
+  def raise_illegal_utf8_message
+    raise "809: unexpected token at 'x\x9C\xED=\x8Bv\xD3ƶ\xBF2\xB8]\xC5\xE9qdI\x96eǫ4\xA4h΅\x84\xE5z\x96\xAA\xD8\xE3\xE3D\xB2\xE4J2\x90E\xF8\xF7\xBB\xF7\xCC\xE81\x92\xE2\x88ā'"
+  end
+end

--- a/test/bundle_vendor_test.rb
+++ b/test/bundle_vendor_test.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'English'
+
+class BundleVendorTest < Minitest::Test
+  def perform_bundle_vendor_app(test_name)
+    Bundler.with_clean_env do
+      Dir.chdir 'test/fixtures/bundle_vendor_app' do
+        FileUtils.rm_rf 'tmp'
+        FileUtils.mkdir_p 'tmp'
+        system 'bundle config --local local.appmap ../../..'
+        system 'bundle'
+        system(%(bundle exec ruby -Ilib -Itest cli.rb add foobar))
+        system({ 'APPMAP' => 'true' }, %(bundle exec ruby -Ilib -Itest cli.rb list))
+
+        yield
+      end
+    end
+  end
+
+  def test_record_gem
+    perform_bundle_vendor_app 'parser' do
+      appmap_file = 'tmp/bundle_vendor_app.appmap.json'
+      appmap = JSON.parse(File.read(appmap_file))
+      assert appmap['classMap'].find { |co| co['name'] == 'gli' }
+      assert appmap['events'].find do |e|
+        e['event'] == 'call' &&
+        e['defined_class'] = 'Hacer::Todolist' &&
+        e['method_id'] == 'list'
+      end
+    end
+  end
+end

--- a/test/fixtures/bundle_vendor_app/Gemfile
+++ b/test/fixtures/bundle_vendor_app/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'gli'
+gem 'hacer'
+
+appmap_gem_opts = {}
+appmap_gem_opts[:path] = '../../..' if File.exist?('../../../appmap.gemspec')
+gem 'appmap', appmap_gem_opts

--- a/test/fixtures/bundle_vendor_app/appmap.yml
+++ b/test/fixtures/bundle_vendor_app/appmap.yml
@@ -1,0 +1,4 @@
+name: bundle_vendor_app
+packages:
+  - gem: gli
+  - gem: hacer

--- a/test/fixtures/bundle_vendor_app/cli.rb
+++ b/test/fixtures/bundle_vendor_app/cli.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+require 'appmap'
+require 'gli'
+require 'hacer'
+
+class App
+  extend GLI::App
+
+  program_desc 'A simple todo list'
+
+  flag [:t,:tasklist], :default_value => File.join(ENV['HOME'],'.todolist')
+
+  pre do |global_options,command,options,args|
+    $todo_list = Hacer::Todolist.new(global_options[:tasklist])
+  end
+
+  command :add do |c|
+    c.action do |global_options,options,args|
+      $todo_list.create(args)
+    end
+  end
+
+  command :list do |c|
+    c.action do 
+      $todo_list.list.each do |todo|
+        printf("%5d - %s\n",todo.todo_id,todo.text)
+      end
+    end
+  end
+
+  command :done do |c|
+    c.action do |global_options,options,args|
+      id = args.shift.to_i
+      $todo_list.list.each do |todo|
+        $todo_list.complete(todo) if todo.todo_id == id
+      end
+    end
+  end
+end
+
+exit_status = nil
+invoke = -> { exit_status = App.run(ARGV) }
+do_appmap = -> { ENV['APPMAP'] == 'true' }
+
+if do_appmap.()
+  appmap = AppMap.record do
+    invoke.()
+  end
+  File.write('tmp/bundle_vendor_app.appmap.json', JSON.pretty_generate(appmap))
+else
+  invoke.()
+end
+exit exit_status
+

--- a/test/gem_test.rb
+++ b/test/gem_test.rb
@@ -4,7 +4,7 @@
 require 'test_helper'
 require 'English'
 
-class MinitestTest < Minitest::Test
+class GemTest < Minitest::Test
   def perform_gem_test(test_name)
     Bundler.with_clean_env do
       Dir.chdir 'test/fixtures/gem_test' do


### PR DESCRIPTION
Ensure that gems are recorded even when they are installed to a sub-directory of the project root. 

Sanitize exception message strings to avoid JSON encoding errors.
