### PR TITLE
feat: Automatically require railtie, minitest, and rspec helpers

### DIFF
--- a/lib/appmap.rb
+++ b/lib/appmap.rb
@@ -51,6 +51,14 @@ module AppMap
       end
     end
 
+    def info(msg)
+      if defined?(::Rails)
+        ::Rails.logger.info msg
+      else
+        warn msg
+      end
+    end
+
     # Used to start tracing, stop tracing, and record events.
     def tracing
       @tracing ||= Trace::Tracing.new
@@ -97,5 +105,17 @@ module AppMap
   end
 end
 
-require 'appmap/railtie' if defined?(::Rails::Railtie)
+if defined?(::Rails::Railtie)
+  require 'appmap/railtie' 
+end
+
+if defined?(::RSpec)
+  require 'appmap/rspec'
+end
+
+# defined?(::Minitest) returns nil...
+if Gem.loaded_specs['minitest']
+  require 'appmap/minitest'
+end
+
 AppMap.initialize if ENV['APPMAP'] == 'true'

--- a/lib/appmap.rb
+++ b/lib/appmap.rb
@@ -52,7 +52,7 @@ module AppMap
     end
 
     def info(msg)
-      if defined?(::Rails)
+      if defined?(::Rails) && defined?(::Rails.logger)
         ::Rails.logger.info msg
       else
         warn msg

--- a/lib/appmap/minitest.rb
+++ b/lib/appmap/minitest.rb
@@ -54,15 +54,21 @@ module AppMap
 
     @recordings_by_test = {}
     @event_methods = Set.new
+    @recording_count = 0
 
     class << self
       def init
-        warn 'Configuring AppMap recorder for Minitest'
-
         FileUtils.mkdir_p APPMAP_OUTPUT_DIR
       end
 
+      def first_recording?
+        @recording_count == 0
+      end
+
       def begin_test(test, name)
+        AppMap.info 'Configuring AppMap recorder for Minitest' if first_recording?
+        @recording_count += 1
+
         @recordings_by_test[test.object_id] = Recording.new(test, name)
       end
 

--- a/lib/appmap/railtie.rb
+++ b/lib/appmap/railtie.rb
@@ -3,6 +3,13 @@
 module AppMap
   # Railtie connects the AppMap recorder to Rails-specific features.
   class Railtie < ::Rails::Railtie
+    initializer 'appmap.remote_recording' do
+      require 'appmap/middleware/remote_recording'
+      Rails.application.config.middleware.insert_after \
+        Rails::Rack::Logger,
+        AppMap::Middleware::RemoteRecording
+    end
+
     # appmap.subscribe subscribes to ActiveSupport Notifications so that they can be recorded as
     # AppMap events.
     initializer 'appmap.subscribe' do |_| # params: app

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -139,15 +139,21 @@ module AppMap
 
     @recordings_by_example = {}
     @event_methods = Set.new
+    @recording_count = 0
 
     class << self
       def init
-        warn 'Configuring AppMap recorder for RSpec'
-
         FileUtils.mkdir_p APPMAP_OUTPUT_DIR
       end
 
+      def first_recording?
+        @recording_count == 0
+      end
+
       def begin_spec(example)
+        AppMap.info 'Configuring AppMap recorder for RSpec' if first_recording?
+        @recording_count += 1
+
         @recordings_by_example[example.object_id] = Recording.new(example)
       end
 

--- a/spec/fixtures/rails5_users_app/config/application.rb
+++ b/spec/fixtures/rails5_users_app/config/application.rb
@@ -21,14 +21,6 @@ when 'activerecord'
   require 'database_cleaner-active_record' if Rails.env.test?
 end
 
-require 'appmap/railtie' if defined?(AppMap)
-
-# require "active_storage/engine"
-# require "action_mailer/railtie"
-# require "action_cable/engine"
-# require "sprockets/railtie"
-# require "rails/test_unit/railtie"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/spec/fixtures/rails5_users_app/config/initializers/record_button.rb
+++ b/spec/fixtures/rails5_users_app/config/initializers/record_button.rb
@@ -1,3 +1,0 @@
-require 'appmap/middleware/remote_recording'
-Rails.application.config.middleware.insert_after Rails::Rack::Logger, AppMap::Middleware::RemoteRecording \
-  unless Rails.env.test?

--- a/spec/fixtures/rails5_users_app/spec/rails_helper.rb
+++ b/spec/fixtures/rails5_users_app/spec/rails_helper.rb
@@ -7,8 +7,6 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
-require 'appmap/rspec'
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/fixtures/rails6_users_app/config/application.rb
+++ b/spec/fixtures/rails6_users_app/config/application.rb
@@ -21,14 +21,6 @@ when 'activerecord'
   require 'database_cleaner-active_record' if Rails.env.test?
 end
 
-require 'appmap/railtie' if defined?(AppMap)
-
-# require "active_storage/engine"
-# require "action_mailer/railtie"
-# require "action_cable/engine"
-# require "sprockets/railtie"
-# require "rails/test_unit/railtie"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/spec/fixtures/rails6_users_app/config/initializers/record_button.rb
+++ b/spec/fixtures/rails6_users_app/config/initializers/record_button.rb
@@ -1,3 +1,0 @@
-require 'appmap/middleware/remote_recording'
-Rails.application.config.middleware.insert_after Rails::Rack::Logger, AppMap::Middleware::RemoteRecording \
-  unless Rails.env.test?

--- a/spec/fixtures/rails6_users_app/spec/rails_helper.rb
+++ b/spec/fixtures/rails6_users_app/spec/rails_helper.rb
@@ -7,8 +7,6 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
-require 'appmap/rspec'
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
* In the context of a Rails app, [require the railtie](https://github.com/applandinc/appmap-ruby/pull/133/files#diff-4ba50e46d8f94bb627d8aeae705c0255d212bb36dae6f5fdff4c78ee316f3f64R108).

* Railtie [configures the app for remote recording automatically](https://github.com/applandinc/appmap-ruby/pull/133/files#diff-d850506678279e89de4e85e240bc997a21f7cd006c90389e795796f3b399936bR6).

* If `minitest` gem is available in the bundle, [add appmap hooks](https://github.com/applandinc/appmap-ruby/pull/133/files#diff-4ba50e46d8f94bb627d8aeae705c0255d212bb36dae6f5fdff4c78ee316f3f64R117).

* If `RSpec` exists, [add appmap hooks](https://github.com/applandinc/appmap-ruby/pull/133/files#diff-4ba50e46d8f94bb627d8aeae705c0255d212bb36dae6f5fdff4c78ee316f3f64R112).
