### PR TITLE
feat: Provide default appmap.yml settings

### DIFF
--- a/lib/appmap.rb
+++ b/lib/appmap.rb
@@ -27,7 +27,7 @@ module AppMap
     # Gets the configuration. If there is no configuration, the default
     # configuration is initialized.
     def configuration
-      @configuration ||= initialize
+      @configuration ||= initialize_configuration
     end
 
     # Sets the configuration. This is only expected to happen once per
@@ -38,12 +38,19 @@ module AppMap
       @configuration = config
     end
 
-    # Configures AppMap for recording. Default behavior is to configure from "appmap.yml".
+    def default_config_file_path
+      ENV['APPMAP_CONFIG_FILE'] || 'appmap.yml'
+    end
+
+    # Configures AppMap for recording. Default behavior is to configure from
+    # APPMAP_CONFIG_FILE, or 'appmap.yml'. If no config file is available, a
+    # configuration will be automatically generated and used - and the user is prompted
+    # to create the config file.
+    #
     # This method also activates the code hooks which record function calls as trace events.
     # Call this function before the program code is loaded by the Ruby VM, otherwise
     # the load events won't be seen and the hooks won't activate.
-    def initialize(config_file_path = 'appmap.yml')
-      raise "AppMap configuration file #{config_file_path} does not exist" unless ::File.exists?(config_file_path)
+    def initialize_configuration(config_file_path = default_config_file_path)
       warn "Configuring AppMap from path #{config_file_path}"
       Config.load_from_file(config_file_path).tap do |configuration|
         self.configuration = configuration
@@ -118,4 +125,4 @@ if Gem.loaded_specs['minitest']
   require 'appmap/minitest'
 end
 
-AppMap.initialize if ENV['APPMAP'] == 'true'
+AppMap.initialize_configuration if ENV['APPMAP'] == 'true'

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -4,6 +4,21 @@ require 'bundler'
 
 module AppMap
   module Util
+    # https://wynnnetherland.com/journal/a-stylesheet-author-s-guide-to-terminal-colors/
+    # Embed in a String to clear all previous ANSI sequences.
+    CLEAR   = "\e[0m"
+    BOLD    = "\e[1m"
+
+    # Colors
+    BLACK   = "\e[30m"
+    RED     = "\e[31m"
+    GREEN   = "\e[32m"
+    YELLOW  = "\e[33m"
+    BLUE    = "\e[34m"
+    MAGENTA = "\e[35m"
+    CYAN    = "\e[36m"
+    WHITE   = "\e[37m"
+
     class << self
       # scenario_filename builds a suitable file name from a scenario name.
       # Special characters are removed, and the file name is truncated to fit within
@@ -127,6 +142,12 @@ module AppMap
           # Atomically move the tempfile into place.
           FileUtils.mv tempfile.path, filename
         end
+      end
+
+      def color(text, color, bold: false)
+        color = Util.const_get(color.to_s.upcase) if color.is_a?(Symbol)
+        bold  = bold ? BOLD : ""
+        "#{bold}#{color}#{text}#{CLEAR}"
       end
     end
   end

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -6,4 +6,6 @@ module AppMap
   VERSION = '0.50.0'
 
   APPMAP_FORMAT_VERSION = '1.5.1'
+
+  DEFAULT_APPMAP_DIR = 'tmp/appmap'.freeze
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -55,4 +55,25 @@ describe AppMap::Config, docker: false do
 
     expect(config.to_h.deep_stringify_keys!).to eq(config_expectation)
   end
+
+  context do
+    let(:warnings) { @warnings ||= [] }
+    let(:warning) { warnings.join }
+    before do
+      expect(AppMap::Config).to receive(:warn).at_least(1) { |msg| warnings << msg }
+    end
+    it 'prints a warning and uses a default config' do
+      config = AppMap::Config.load_from_file 'no/such/file'
+      expect(config.to_h).to eq(YAML.load(<<~CONFIG))
+      :name: appmap-ruby
+      :packages:
+      - :path: lib
+        :handler_class: AppMap::Handler::Function
+        :shallow: false
+      :functions: []
+      :exclude: []
+      CONFIG
+      expect(warning).to include('NOTICE: The AppMap config file no/such/file was not found!')
+    end
+  end
 end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -21,7 +21,7 @@ describe 'AppMap class Hooking', docker: false do
   def invoke_test_file(file, setup: nil, &block)
     AppMap.configuration = nil
     package = AppMap::Config::Package.build_from_path(file)
-    config = AppMap::Config.new('hook_spec', [ package ])
+    config = AppMap::Config.new('hook_spec', packages: [ package ])
     AppMap.configuration = config
     tracer = nil
     AppMap::Hook.new(config).enable do
@@ -57,7 +57,7 @@ describe 'AppMap class Hooking', docker: false do
   it 'excludes named classes and methods' do
     load 'spec/fixtures/hook/exclude.rb'
     package = AppMap::Config::Package.build_from_path('spec/fixtures/hook/exclude.rb')
-    config = AppMap::Config.new('hook_spec', [ package ], exclude: %w[ExcludeTest])
+    config = AppMap::Config.new('hook_spec', packages: [ package ], exclude: %w[ExcludeTest])
     AppMap.configuration = config
 
     expect(config.never_hook?(ExcludeTest, ExcludeTest.new.method(:instance_method))).to be_truthy

--- a/spec/record_net_http_spec.rb
+++ b/spec/record_net_http_spec.rb
@@ -62,7 +62,7 @@ describe 'Net::HTTP handler' do
   end
 
   context 'with trace enabled' do
-    let(:configuration) { AppMap::Config.new('record_net_http_spec', []) }
+    let(:configuration) { AppMap::Config.new('record_net_http_spec') }
 
     after do
       AppMap.configuration = nil


### PR DESCRIPTION
If appmap.yml is not found, warn the user.
Detect some possible source paths, and the project name from the .git file,
and use this info to create a temporary appmap.yml.
Print it to the console so the user can use it as a starting point.

<img width="897" alt="Screen Shot 2021-06-18 at 3 05 22 PM" src="https://user-images.githubusercontent.com/86395/122606245-9cafff00-d046-11eb-9c39-2fe423a8d1a9.png">


