### PR TITLE
fix: Fix problems with auto-requiring appmap modules

### DIFF
--- a/lib/appmap.rb
+++ b/lib/appmap.rb
@@ -112,17 +112,19 @@ module AppMap
   end
 end
 
-if defined?(::Rails::Railtie)
+if Gem.loaded_specs['rails']
+  require 'active_support'
+  require 'active_support/core_ext'
+  require 'rails'
   require 'appmap/railtie' 
 end
 
-if defined?(::RSpec)
+if Gem.loaded_specs['rspec-core']
   require 'appmap/rspec'
 end
-
-# defined?(::Minitest) returns nil...
+  
 if Gem.loaded_specs['minitest']
   require 'appmap/minitest'
 end
-
+  
 AppMap.initialize_configuration if ENV['APPMAP'] == 'true'

--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -284,7 +284,7 @@ module AppMap
           settings, the appmap gem will try and guess some reasonable defaults.
           To suppress this message, create the file:
           
-          #{Pathname.new(config_file_name).expand_path}.
+          #{Pathname.new(config_file_name).expand_path}
           
           Here are the default settings that will be used in the meantime. You can
           copy and paste this example to start your appmap.yml.

--- a/lib/appmap/handler/rails/template.rb
+++ b/lib/appmap/handler/rails/template.rb
@@ -14,16 +14,30 @@ module AppMap
         # The class name is generated from the template path. The package name is
         # 'app/views', and the method name is 'render'. The source location of the method
         # is, of course, the path to the view template.
-        TemplateMethod = Struct.new(:path) do
-          private_instance_methods :path
+        class TemplateMethod
           attr_reader :class_name
- 
+
+          attr_reader :path
+          private_instance_methods :path
+
           def initialize(path)
-            super
+            @path = path
 
             @class_name = path.parameterize.underscore
           end
-  
+
+          def id
+            [ package, path, name ]
+          end
+
+          def hash
+            id.hash
+          end
+
+          def eql?(other)
+            other.is_a?(TemplateMethod) && id.eql?(other.id)
+          end
+
           def package
             'app/views'
           end

--- a/lib/appmap/trace.rb
+++ b/lib/appmap/trace.rb
@@ -2,10 +2,12 @@
 
 module AppMap
   module Trace
-    class RubyMethod
+    class RubyMethod < SimpleDelegator
       attr_reader :class_name, :static
 
       def initialize(package, class_name, method, static)
+        super(method)
+
         @package = package
         @class_name = class_name
         @method = method
@@ -111,7 +113,7 @@ module AppMap
       @last_package_for_thread[Thread.current.object_id] = package if package
       @events << event
       static = event.static if event.respond_to?(:static)
-      @methods << Trace::RubyMethod.new(package, defined_class, method, static) \
+      record_method Trace::RubyMethod.new(package, defined_class, method, static) \
         if package && defined_class && method && (event.event == :call)
     end
 


### PR DESCRIPTION
`if defined?(::Rails::Railtie)` doesn't reliably return true, due to load order issues. So, we also use TracePoint to watch modules being loaded.

This PR also removes redundant methods from the ClassMap, by ensuring that method objects are well-behaved in a Set.
