### PR TITLE
fix: Workaround Ruby bug in 2.7.3 with kwrest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: ruby
 
+rbenv:
+- 2.5
+- 2.6
+- 2.7
+
 addons:
   apt:
     packages:
@@ -38,7 +43,6 @@ jobs:
     - mkdir tmp
     - GEM_ALTERNATIVE_NAME='' bundle exec rake test
 
-    
 before_deploy:
   - |
     nvm install --lts \

--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,7 @@ require 'rake/testtask'
 require 'rdoc/task'
 
 require 'open3'
-
-require "rake/extensiontask"
+require 'rake/extensiontask'
 
 desc 'build the native extension'
 Rake::ExtensionTask.new("appmap") do |ext|
@@ -26,7 +25,7 @@ namespace 'gem' do
       # ~/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/gem_helper.rb:39:in `install'
       def build_gem
         # Ensure that NPM packages are installed before building.
-        sh('yarn install --prod'.shellsplit)
+        sh('yarn install --prod')
   
         default_build_gem
       end
@@ -34,7 +33,17 @@ namespace 'gem' do
   end
 end
 
-RUBY_VERSIONS=%w[2.5 2.6 2.7]
+RUBY_VERSIONS=%w[2.5 2.6 2.7].select do |version|
+  travis_ruby_version = ENV['TRAVIS_RUBY_VERSION']
+  next true unless travis_ruby_version
+
+  if travis_ruby_version.index(version) == 0
+    warn "Testing Ruby version #{version}, since it matches TRAVIS_RUBY_VERSION=#{travis_ruby_version}"
+    next true
+  end
+
+  false
+end
 FIXTURE_APPS=%w[rack_users_app rails6_users_app rails5_users_app]
 
 def run_cmd(*cmd)

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -54,4 +54,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webdrivers', '~> 4.0'
   spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'hashie'
+  spec.add_development_dependency 'webrick'
 end

--- a/lib/appmap/handler/net_http.rb
+++ b/lib/appmap/handler/net_http.rb
@@ -82,7 +82,7 @@ module AppMap
         def request_headers(request)
           {}.tap do |headers|
             request.each_header do |k,v|
-              key = [ 'HTTP', k.underscore.upcase ].join('_')
+              key = [ 'HTTP', Util.underscore(k).upcase ].join('_')
               headers[key] = v
             end
           end

--- a/lib/appmap/handler/rails/template.rb
+++ b/lib/appmap/handler/rails/template.rb
@@ -146,7 +146,8 @@ module AppMap
         class RenderHandler
           class << self
             def handle_call(defined_class, hook_method, receiver, args)
-              context, options = args
+              # context, options
+              _, options = args
 
               warn "Renderer: #{options}" if LOG
 

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -99,7 +99,6 @@ module AppMap
     end
 
     def trace_end(trace_point)
-      location = trace_location(trace_point)
       warn "Class or module ends at location #{trace_location(trace_point)}" if Hook::LOG || Hook::LOG_HOOK
 
       path = trace_point.path

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -18,6 +18,8 @@ module AppMap
       TIME_NOW = Time.method(:now)
       private_constant :TIME_NOW
 
+      ARRAY_OF_EMPTY_HASH = [{}.freeze].freeze
+
       def initialize(hook_package, hook_class, hook_method)
         @hook_package = hook_package
         @hook_class = hook_class
@@ -45,42 +47,48 @@ module AppMap
         after_hook = self.method(:after_hook)
         with_disabled_hook = self.method(:with_disabled_hook)
 
-        hook_method_def = nil
-        hook_class.instance_eval do 
-          hook_method_def = Proc.new do |*args, &block|
-            instance_method = hook_method.bind(self).to_proc
-            call_instance_method = -> { instance_method.call(*args, &block) }
-
-            # We may not have gotten the class for the method during
-            # initialization (e.g. for a singleton method on an embedded
-            # struct), so make sure we have it now.
-            defined_class, = Hook.qualify_method_name(hook_method) unless defined_class
-
-            reentrant = Thread.current[HOOK_DISABLE_KEY]
-            disabled_by_shallow_flag = \
-              -> { hook_package&.shallow? && AppMap.tracing.last_package_for_current_thread == hook_package }
-
-            enabled = true if AppMap.tracing.enabled? && !reentrant && !disabled_by_shallow_flag.call
-
-            return call_instance_method.call unless enabled
-
-            call_event, start_time = with_disabled_hook.call do
-              before_hook.call(self, defined_class, args)
+        hook_method_def = Proc.new do |*args, &block|
+          instance_method = hook_method.bind(self).to_proc
+          call_instance_method = -> {
+            # https://github.com/applandinc/appmap-ruby/issues/153
+            if Util.ruby_minor_version >= 2.7 && args == ARRAY_OF_EMPTY_HASH && hook_method.arity == 1
+              instance_method.call({}, &block)
+            else
+              instance_method.call(*args, &block)
             end
-            return_value = nil
-            exception = nil
-            begin
-              return_value = call_instance_method.call
-            rescue
-              exception = $ERROR_INFO
-              raise
-            ensure
-              with_disabled_hook.call do
-                after_hook.call(self, call_event, start_time, return_value, exception) if call_event
-              end
+          }
+
+          # We may not have gotten the class for the method during
+          # initialization (e.g. for a singleton method on an embedded
+          # struct), so make sure we have it now.
+          defined_class, = Hook.qualify_method_name(hook_method) unless defined_class
+
+          reentrant = Thread.current[HOOK_DISABLE_KEY]
+          disabled_by_shallow_flag = \
+            -> { hook_package&.shallow? && AppMap.tracing.last_package_for_current_thread == hook_package }
+
+          enabled = true if AppMap.tracing.enabled? && !reentrant && !disabled_by_shallow_flag.call
+
+          return call_instance_method.call unless enabled
+
+          call_event, start_time = with_disabled_hook.call do
+            before_hook.call(self, defined_class, args)
+          end
+          return_value = nil
+          exception = nil
+          begin
+            return_value = call_instance_method.call
+          rescue
+            exception = $ERROR_INFO
+            raise
+          ensure
+            with_disabled_hook.call do
+              after_hook.call(self, call_event, start_time, return_value, exception) if call_event
             end
           end
         end
+        hook_method_def = hook_method_def.ruby2_keywords if hook_method_def.respond_to?(:ruby2_keywords)
+
         hook_class.define_method_with_arity(hook_method.name, hook_method.arity, hook_method_def)
       end
 

--- a/lib/appmap/trace.rb
+++ b/lib/appmap/trace.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'delegate'
+
 module AppMap
   module Trace
     class RubyMethod < SimpleDelegator

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -178,6 +178,10 @@ module AppMap
           warn msg
         end
       end  
+
+      def ruby_minor_version
+        @ruby_minor_version ||= RUBY_VERSION.split('.')[0..1].join('.').to_f
+      end
     end
   end
 end

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -124,7 +124,7 @@ module AppMap
         path = path.split('(.')[0]
         tokens = path.split('/')
         tokens.map do |token|
-          token.gsub /^:(.*)/, '{\1}'
+          token.gsub(/^:(.*)/, '{\1}')
         end.join('/')
       end
 
@@ -152,6 +152,18 @@ module AppMap
 
       def classify(word)
         word.split(/[\-_]/).map(&:capitalize).join
+      end
+
+      # https://api.rubyonrails.org/v6.1.3.2/classes/ActiveSupport/Inflector.html#method-i-underscore
+      def underscore(camel_cased_word)
+        return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+        word = camel_cased_word.to_s.gsub("::", "/")
+        # word.gsub!(inflections.acronyms_underscore_regex) { "#{$1 && '_' }#{$2.downcase}" }
+        word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+        word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+        word.tr!("-", "_")
+        word.downcase!
+        word
       end
 
       def deep_dup(hash)

--- a/spec/fixtures/hook/kwargs.rb
+++ b/spec/fixtures/hook/kwargs.rb
@@ -1,0 +1,11 @@
+class Kwargs
+  class << self
+    def no_kwargs(args)
+      args
+    end
+
+    def has_kwrest_calls_no_kwargs(args, **kwargs)
+      no_kwargs(**kwargs)
+    end
+  end
+end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -985,4 +985,13 @@ describe 'AppMap class Hooking', docker: false do
       expect(InstanceMethod.new.method(:say_echo).arity).to be(1)
     end
   end
+
+  describe 'kwargs handling' do
+    # https://github.com/applandinc/appmap-ruby/issues/153
+    it 'empty hash for **kwrest can be proxied as a regular function argument', github_issue: 153 do
+      invoke_test_file 'spec/fixtures/hook/kwargs.rb' do
+        expect(Kwargs.has_kwrest_calls_no_kwargs(nil, {})).to eq({})
+      end
+    end
+  end
 end

--- a/spec/record_net_http_spec.rb
+++ b/spec/record_net_http_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'diffy'
 require 'rack'
+require 'webrick'
 require 'rack/handler/webrick'
 
 class HelloWorldApp


### PR DESCRIPTION
There are two main elements to this fix:

* Call https://ruby-doc.org/core-2.7.0/Proc.html#method-i-ruby2_keywords
* Fix a probable side-effect of using ruby_keywords: https://github.com/applandinc/appmap-ruby/pull/154/files#diff-95a15f6e0d63580f2d31bf5a2e866f1062fbda51da73ad9089c579b952467a08R54

Fixes https://github.com/applandinc/appmap-ruby/issues/153
