### PR TITLE
fix: Get deployment working with packaging of NodeJS code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 
 rbenv:
-- 2.5
-- 2.6
 - 2.7
 
 addons:
@@ -34,27 +32,30 @@ before_install:
   - |
     nvm install --lts \
       && nvm use --lts
- 
+
 # GEM_ALTERNATIVE_NAME only needed for deployment 
 jobs:
   include:
   - stage: test
     script:
+    - set -e
     - mkdir tmp
-    - GEM_ALTERNATIVE_NAME='' bundle exec rake test
+    - npm i -g yarn
+    - GEM_ALTERNATIVE_NAME='' bundle exec rake gem:build test
 
 before_deploy:
   - |
-    nvm install --lts \
-      && nvm use --lts \
-      && npm i -g \
-        semantic-release \
-        @semantic-release/git \
-        @semantic-release/changelog \
-        semantic-release-rubygem
+    npm i -g \
+      yarn \
+      semantic-release \
+      @semantic-release/git \
+      @semantic-release/changelog \
+      semantic-release-rubygem
 
 deploy:
   - provider: script
     script: ./release.sh
     on:
-      branch: master
+      branch: fix-swagger-deploy
+      condition: "$TRAVIS_RUBY_VERSION = 2.7"
+

--- a/release.sh
+++ b/release.sh
@@ -13,5 +13,4 @@ else
 fi
 
 set -x
-exec semantic-release $RELEASE_FLAGS
-
+echo exec semantic-release $RELEASE_FLAGS


### PR DESCRIPTION
Tests are failing and deployment is happening with NodeJS code:

```
["docker-compose run --rm -v /home/travis/build/applandinc/appmap-ruby/tmp/spec/AbstractControllerBase:/app/tmp app ./bin/rake appmap:swagger ", {:chdir=>"spec/fixtures/rails6_users_app"}]
<<< Output:
Starting rails6_users_app_pg_1_cb35fb729c41 ... 
AppMap::CommandError: Command failed: ["node", "/usr/local/bundle/gems/appmap-0.54.2/node_modules/@appland/cli/src/cli.js", "swagger"]; stderr: internal/modules/cjs/loader.js:905
stderr:   throw err;
stderr:   ^
stderr: 
stderr: Error: Cannot find module '/usr/local/bundle/gems/appmap-0.54.2/node_modules/@appland/cli/src/cli.js'
stderr:     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
stderr:     at Function.Module._load (internal/modules/cjs/loader.js:746:27)
stderr:     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
stderr:     at internal/main/run_main_module.js:17:47 {
stderr:   code: 'MODULE_NOT_FOUND',
stderr:   requireStack: []
stderr: }
/usr/local/bundle/gems/appmap-0.54.2/lib/appmap/node_cli.rb:46:in `command'
/usr/local/bundle/gems/appmap-0.54.2/lib/appmap/swagger/rake_tasks.rb:25:in `block in define_tasks'
/usr/local/bundle/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
Tasks: TOP => appmap:swagger
(See full trace by running task with --trace)
>>> End of output
F.......
Failures:
  1) rake appmap:swagger generates openapi_stable.yml
     Failure/Error: raise 'Command failed'
     RuntimeError:
       Command failed
     # ./spec/rails_spec_helper.rb:31:in `run_cmd'
     # ./spec/swagger/swagger_spec.rb:19:in `generate_swagger'
     # ./spec/swagger/swagger_spec.rb:24:in `block (2 levels) in <top (required)>'
Finished in 2 minutes 11.2 seconds (files took 0.49644 seconds to load)
81 examples, 1 failure
Failed examples:
rspec ./spec/swagger/swagger_spec.rb:31 # rake appmap:swagger generates openapi_stable.yml
/home/travis/.rvm/rubies/ruby-2.7.1/bin/ruby -I/home/travis/build/applandinc/appmap-ruby/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.10.1/lib:/home/travis/build/applandinc/appmap-ruby/vendor/bundle/ruby/2.7.0/gems/rspec-support-3.10.2/lib /home/travis/build/applandinc/appmap-ruby/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb  --exclude-pattern spec/fixtures/\*\*/\*_spec.rb failed
The command "bundle exec rake" exited with 1.
cache.2
store build cache
Done. Your build exited with 1.
```