### PR TITLE
feat: Add `test_commands` sections to `appmap-agent-status` executable

### DIFF
--- a/lib/appmap/command/agent_setup/status.rb
+++ b/lib/appmap/command/agent_setup/status.rb
@@ -2,6 +2,8 @@
 
 require 'json'
 require 'appmap/service/config_analyzer'
+require 'appmap/service/integration_test_path_finder'
+require 'appmap/service/test_command_provider'
 
 module AppMap
   module Command
@@ -11,22 +13,23 @@ module AppMap
       class Status < StatusStruct
         def perform
           status = {
-            :properties => {
-              :config => {
-                :app => config_analyzer.app_name,
-                :present => config_analyzer.present?,
-                :valid => config_analyzer.valid?
+            test_commands: Service::TestCommandProvider.all,
+            properties: {
+              config: {
+                app: config_analyzer.app_name,
+                present: config_analyzer.present?,
+                valid: config_analyzer.valid?
               },
-              :project => {
-                :agentVersion => AppMap::VERSION,
-                :language => 'ruby',
-                :remoteRecordingCapable => Gem.loaded_specs.has_key?('rails'),
-                :integrationTests => false #TODO
+              project: {
+                agentVersion: AppMap::VERSION,
+                language: 'ruby',
+                remoteRecordingCapable: Gem.loaded_specs.has_key?('rails'),
+                integrationTests: Service::IntegrationTestPathFinder.count_paths > 0
               }
             }
           }
 
-          puts status.to_json
+          puts JSON.pretty_generate(status)
         end
 
         private

--- a/lib/appmap/service/integration_test_path_finder.rb
+++ b/lib/appmap/service/integration_test_path_finder.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'appmap/service/test_framework_detector'
+
+module AppMap
+  module Service
+    class IntegrationTestPathFinder
+      class << self
+        def find
+          @paths ||= begin
+            paths = { rspec: [], minitest: [], cucumber: [] }
+            paths[:rspec] = find_rspec_paths if TestFrameworkDetector.rspec_present?
+            paths[:minitest] = find_minitest_paths if TestFrameworkDetector.minitest_present?
+            paths[:cucumber] = find_cucumber_paths if TestFrameworkDetector.cucumber_present?
+            paths
+          end
+        end
+
+        def count_paths
+          find.flatten(2).length - 3
+        end
+
+        private
+
+        def find_rspec_paths
+          find_non_empty_paths(%w[spec/controllers spec/requests spec/integration spec/api spec/features spec/system])
+        end
+
+
+        def find_minitest_paths
+          find_non_empty_paths(%w[test/controllers test/integration])
+        end
+
+        def find_cucumber_paths
+          find_non_empty_paths(%w[features])
+        end
+
+        def find_non_empty_paths(paths)
+          paths.select { |path| Dir.exist?(path) && !Dir.empty?(path) }
+        end
+      end
+    end
+  end
+end

--- a/lib/appmap/service/test_command_provider.rb
+++ b/lib/appmap/service/test_command_provider.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'appmap/service/test_framework_detector'
+require 'appmap/service/integration_test_path_finder'
+
+module AppMap
+  module Service
+    class TestCommandProvider
+      class << self
+        def all
+          commands = []
+
+          if TestFrameworkDetector.rspec_present? && !integration_test_paths[:rspec].empty?
+            commands << {
+              framework: :rspec,
+              command: "APPMAP=true bundle exec rspec #{integration_test_paths[:rspec].join(' ')}"
+            }
+          end
+
+          if TestFrameworkDetector.minitest_present? && !integration_test_paths[:minitest].empty?
+            commands << {
+              framework: :minitest,
+              command: minitest_command
+            }
+          end
+
+          if TestFrameworkDetector.cucumber_present? && !integration_test_paths[:cucumber].empty?
+            commands << {
+              framework: :cucumber,
+              command: 'APPMAP=true bundle exec cucumber'
+            }
+          end
+
+          commands
+        end
+
+        private
+
+        def minitest_command
+          if Gem.loaded_specs.has_key?('rails')
+            "APPMAP=true bundle exec rails test #{integration_test_paths[:minitest].join(' ')}"
+          else
+            subcommands = integration_test_paths[:minitest].map { |path| "APPMAP=true bundle exec ruby #{path}" }
+            subcommands.join(' && ')
+          end
+        end
+
+        def integration_test_paths
+          @paths ||= Service::IntegrationTestPathFinder.find
+        end
+      end
+    end
+  end
+end

--- a/lib/appmap/service/test_framework_detector.rb
+++ b/lib/appmap/service/test_framework_detector.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module AppMap
+  module Service
+    class TestFrameworkDetector
+      class << self
+        def rspec_present?
+          Gem.loaded_specs.has_key?('rspec-core')
+        end
+
+        def minitest_present?
+          Gem.loaded_specs.has_key?('minitest')
+        end
+
+        def cucumber_present?
+          Gem.loaded_specs.has_key?('cucumber')
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/rails6_users_app/test/controllers/functional_calc_test.rb
+++ b/spec/fixtures/rails6_users_app/test/controllers/functional_calc_test.rb
@@ -1,0 +1,10 @@
+# minitest_calc_test_unit_format_spec.rb
+
+require "minitest/autorun"
+
+class FunctionalCalcTest < Minitest::Test
+  def test_add
+    puts 'functional'
+    assert_equal 2 + 2, 4
+  end
+end

--- a/spec/fixtures/rails6_users_app/test/integration/integration_calc_test.rb
+++ b/spec/fixtures/rails6_users_app/test/integration/integration_calc_test.rb
@@ -1,0 +1,12 @@
+# minitest_calc_test_unit_format_spec.rb
+
+require "minitest/autorun"
+
+class IntegrationCalcTest < Minitest::Test
+  class CalcTest < Minitest::Test
+    def test_add
+      puts 'integration'
+      assert_equal 2 + 2, 4
+    end
+  end
+end

--- a/test/agent_setup_status_test.rb
+++ b/test/agent_setup_status_test.rb
@@ -4,24 +4,62 @@
 require 'test_helper'
 
 class AgentSetupInitTest < Minitest::Test
-  def test_status
+  def test_status_gem
     output = `./exe/appmap-agent-status`
     assert_equal 0, $CHILD_STATUS.exitstatus
     expected = {
-      :properties => {
-        :config => {
-          :app => 'AppMap Rubygem',
-          :present => true,
-          :valid => true
+      test_commands: [],
+      properties: {
+        config: {
+          app: 'AppMap Rubygem',
+          present: true,
+          valid: true
         },
-        :project => {
-          :agentVersion => AppMap::VERSION,
-          :language => 'ruby',
-          :remoteRecordingCapable => false,
-          :integrationTests => false
+        project: {
+          agentVersion: AppMap::VERSION,
+          language: 'ruby',
+          remoteRecordingCapable: false,
+          integrationTests: false
         }
       }
-    }.to_json
-    assert_equal expected, output.strip
+    }
+    assert_equal JSON.pretty_generate(expected), output.strip
+  end
+
+  def test_status_rails_app
+    def test_status
+      output = `cd spec/fixtures/rails6_users_app && bundle exec ../../../exe/appmap-agent-status`
+      assert_equal 0, $CHILD_STATUS.exitstatus
+      expected = {
+        test_commands: [
+          {
+            framework: :rspec,
+            command: 'APPMAP=true bundle exec rspec spec/controllers'
+          },
+          {
+            framework: :minitest,
+            command: 'APPMAP=true bundle exec ruby test/controllers && APPMAP=true bundle exec ruby test/integration'
+          },
+          {
+            framework: :cucumber,
+            command: 'APPMAP=true bundle exec cucumber'
+          }
+        ],
+        properties: {
+          config: {
+            app: nil,
+            present: true,
+            valid: true
+          },
+          project: {
+            agentVersion: AppMap::VERSION,
+            language: 'ruby',
+            remoteRecordingCapable: false,
+            integrationTests: true
+          }
+        }
+      }
+      assert_equal JSON.pretty_generate(expected), output.strip
+    end
   end
 end


### PR DESCRIPTION
Example output for `rails6_users_app`:
```json
{
  "test_commands": [
    {
      "framework": "rspec",
      "command": "APPMAP=true bundle exec rspec spec/controllers"
    },
    {
      "framework": "minitest",
      "command": "APPMAP=true bundle exec rails test test/controllers test/integration"
    },
    {
      "framework": "cucumber",
      "command": "APPMAP=true bundle exec cucumber"
    }
  ],
  "properties": {
    "config": {
      "app": "rails6_users_app",
      "present": true,
      "valid": true
    },
    "project": {
      "agentVersion": "0.57.0",
      "language": "ruby",
      "remoteRecordingCapable": true,
      "integrationTests": true
    }
  }
}
```