### PR TITLE
fix: Events may be constructed in stages

### DIFF
--- a/lib/appmap/event.rb
+++ b/lib/appmap/event.rb
@@ -119,6 +119,14 @@ module AppMap
           end
         end
       end
+      
+      # An event may be partially constructed, and then completed at a later time. When the event
+      # is only partially constructed, it's not ready for serialization to the AppMap file. 
+      # 
+      # @return false until the event is fully constructed and available.
+      def ready?
+        true
+      end
 
       protected
 

--- a/lib/appmap/handler/rails/template.rb
+++ b/lib/appmap/handler/rails/template.rb
@@ -71,11 +71,16 @@ module AppMap
           attr_reader :render_instance
           # Path to the view template.
           attr_accessor :path
-  
+          # Indicates when the event is fully constructed.
+          attr_accessor :ready
+
+          alias ready? ready
+ 
           def initialize(render_instance)
             super :call
   
             AppMap::Event::MethodEvent.build_from_invocation(:call, event: self)
+            @ready = false
             @render_instance = render_instance
           end
   
@@ -95,8 +100,7 @@ module AppMap
                 object_id: render_instance.__id__,
                 value: AppMap::Event::MethodEvent.display_string(render_instance)
               }
-              h.compact
-            end
+            end.compact
           end
         end
  
@@ -158,7 +162,8 @@ module AppMap
             end
   
             def handle_return(call_event_id, elapsed, return_value, exception)
-              Array(Thread.current[TEMPLATE_RENDERER]).pop
+              template_call = Array(Thread.current[TEMPLATE_RENDERER]).pop
+              template_call.ready = true
 
               AppMap::Event::MethodReturnIgnoreValue.build_from_invocation(call_event_id, elapsed: elapsed)
             end

--- a/lib/appmap/trace.rb
+++ b/lib/appmap/trace.rb
@@ -143,12 +143,12 @@ module AppMap
 
     # Whether there is an event available for processing.
     def event?
-      !@events.empty?
+      !@events.empty? && @events.first.ready?
     end
 
     # Gets the next available event, if any.
     def next_event
-      @events.shift
+      @events.shift if event?
     end
   end
 end


### PR DESCRIPTION
An event may be partially constructed, and then completed at a later time.
When the event is only partially constructed, it's not ready for serialization to the AppMap file.

This problem manifests when a thread is continually pulling
and serializing events. For example, during remote recording.