### PR TITLE
fix: Remove improper reliance on Rails 'try'

### DIFF
--- a/lib/appmap/event.rb
+++ b/lib/appmap/event.rb
@@ -248,7 +248,7 @@ module AppMap
               next_exception = exception
               exceptions = []
               while next_exception
-                exception_backtrace = next_exception.backtrace_locations.try(:[], 0)
+                exception_backtrace = AppMap::Util.try(next_exception.backtrace_locations, :[], 0)
                 exceptions << {
                   class: best_class_name(next_exception),
                   message: display_string(next_exception.message),

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -183,6 +183,15 @@ module AppMap
         false
       end
 
+      # https://github.com/rails/rails/blob/8cd143900978902ed9bbba10b34099a3140de5c6/activesupport/lib/active_support/core_ext/object/try.rb
+      def try(obj, *methods)
+        return nil if methods.empty?
+
+        return nil unless obj.respond_to?(methods.first)
+
+        obj.public_send(*methods)
+      end
+
       def startup_message(msg)
         if defined?(::Rails) && defined?(::Rails.logger) && ::Rails.logger
           ::Rails.logger.info msg


### PR DESCRIPTION
Unless a Rails environment is assured, don't use 'try'.
Add a simplified, equivalent method to AppMap::Util.