### PR TITLE
feat: Include children `controllers` and `integration` folders into minitest paths

### DIFF
--- a/lib/appmap/command/agent_setup/status.rb
+++ b/lib/appmap/command/agent_setup/status.rb
@@ -24,7 +24,7 @@ module AppMap
                 agentVersion: AppMap::VERSION,
                 language: 'ruby',
                 remoteRecordingCapable: Gem.loaded_specs.has_key?('rails'),
-                integrationTests: Service::IntegrationTestPathFinder.count_paths > 0
+                integrationTests: Service::IntegrationTestPathFinder.new.count_paths > 0
               }
             }
           }

--- a/lib/appmap/service/integration_test_path_finder.rb
+++ b/lib/appmap/service/integration_test_path_finder.rb
@@ -28,7 +28,7 @@ module AppMap
 
 
         def find_minitest_paths
-          find_non_empty_paths(%w[test/controllers test/integration])
+          find_non_empty_paths(Dir.glob('test/**/{controllers,integration}').sort)
         end
 
         def find_cucumber_paths

--- a/lib/appmap/service/integration_test_path_finder.rb
+++ b/lib/appmap/service/integration_test_path_finder.rb
@@ -5,39 +5,43 @@ require 'appmap/service/test_framework_detector'
 module AppMap
   module Service
     class IntegrationTestPathFinder
-      class << self
-        def find
-          @paths ||= begin
-            paths = { rspec: [], minitest: [], cucumber: [] }
-            paths[:rspec] = find_rspec_paths if TestFrameworkDetector.rspec_present?
-            paths[:minitest] = find_minitest_paths if TestFrameworkDetector.minitest_present?
-            paths[:cucumber] = find_cucumber_paths if TestFrameworkDetector.cucumber_present?
-            paths
-          end
+      def initialize(base_path = '')
+        @base_path = base_path
+      end
+
+      def find
+        @paths ||= begin
+          paths = { rspec: [], minitest: [], cucumber: [] }
+          paths[:rspec] = find_rspec_paths if TestFrameworkDetector.rspec_present?
+          paths[:minitest] = find_minitest_paths if TestFrameworkDetector.minitest_present?
+          paths[:cucumber] = find_cucumber_paths if TestFrameworkDetector.cucumber_present?
+          paths
         end
+      end
 
-        def count_paths
-          find.flatten(2).length - 3
-        end
+      def count_paths
+        find.flatten(2).length - 3
+      end
 
-        private
+      private
 
-        def find_rspec_paths
-          find_non_empty_paths(%w[spec/controllers spec/requests spec/integration spec/api spec/features spec/system])
-        end
+      def find_rspec_paths
+        find_non_empty_paths(%w[spec/controllers spec/requests spec/integration spec/api spec/features spec/system])
+      end
 
 
-        def find_minitest_paths
-          find_non_empty_paths(Dir.glob('test/**/{controllers,integration}').sort)
-        end
+      def find_minitest_paths
+        top_level_paths = %w[test/controllers test/integration]
+        children_paths = Dir.glob('test/**/{controllers,integration}')
+        find_non_empty_paths((top_level_paths + children_paths).uniq).sort
+      end
 
-        def find_cucumber_paths
-          find_non_empty_paths(%w[features])
-        end
+      def find_cucumber_paths
+        find_non_empty_paths(%w[features])
+      end
 
-        def find_non_empty_paths(paths)
-          paths.select { |path| Dir.exist?(path) && !Dir.empty?(path) }
-        end
+      def find_non_empty_paths(paths)
+        paths.select { |path| Dir.exist?(@base_path + path) && !Dir.empty?(@base_path + path) }
       end
     end
   end

--- a/lib/appmap/service/test_command_provider.rb
+++ b/lib/appmap/service/test_command_provider.rb
@@ -69,7 +69,7 @@ module AppMap
         end
 
         def integration_test_paths
-          @paths ||= Service::IntegrationTestPathFinder.find
+          @paths ||= Service::IntegrationTestPathFinder.new.find
         end
       end
     end

--- a/spec/service/integration_test_path_finder_spec.rb
+++ b/spec/service/integration_test_path_finder_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'appmap/service/integration_test_path_finder'
+
+describe AppMap::Service::IntegrationTestPathFinder do
+  subject { described_class }
+
+  describe '.count' do
+    it 'counts existing paths' do
+      expect(subject.count_paths).to be(0)
+    end
+  end
+
+  describe '.find' do
+    it 'finds paths' do
+      expect(subject.find).to eq({ rspec: [], minitest: [], cucumber: [] })
+    end
+  end
+end

--- a/spec/service/integration_test_path_finder_spec.rb
+++ b/spec/service/integration_test_path_finder_spec.rb
@@ -4,17 +4,21 @@ require 'spec_helper'
 require 'appmap/service/integration_test_path_finder'
 
 describe AppMap::Service::IntegrationTestPathFinder do
-  subject { described_class }
+  subject { described_class.new('./spec/fixtures/rails6_users_app/') }
 
   describe '.count' do
     it 'counts existing paths' do
-      expect(subject.count_paths).to be(0)
+      expect(subject.count_paths).to be(3)
     end
   end
 
   describe '.find' do
     it 'finds paths' do
-      expect(subject.find).to eq({ rspec: [], minitest: [], cucumber: [] })
+      expect(subject.find).to eq({
+        rspec: %w[spec/controllers],
+        minitest: %w[test/controllers test/integration],
+        cucumber: []
+      })
     end
   end
 end


### PR DESCRIPTION
@ptrdvrk found an app where tests are located in `test/internal/app/controllers`. We can easily include children dirs into the list of possible paths.