### PR TITLE
Update version and changelog for 0.62.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.62.1](https://github.com/applandinc/appmap-ruby/compare/v0.62.0...v0.62.1) (2021-08-06)
+
+* Ensure that `node_modules` is present in the release.
+
 # [0.62.0](https://github.com/applandinc/appmap-ruby/compare/v0.61.1...v0.62.0) (2021-07-21)
 
 

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -3,7 +3,7 @@
 module AppMap
   URL = 'https://github.com/applandinc/appmap-ruby'
 
-  VERSION = '0.62.0'
+  VERSION = '0.62.1'
 
   APPMAP_FORMAT_VERSION = '1.5.1'
 


### PR DESCRIPTION
node_modules is missing from 0.62.0. This gem version will be published manually while we troubleshoot.