### PR TITLE
fix: Run yarn install --prod in ./release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -12,5 +12,6 @@ else
     echo "No GEM_ALTERNATIVE_NAME is provided, releasing gem with default name ('appmap')"
 fi
 
-set -x
+set -ex
+yarn install --prod
 exec semantic-release $RELEASE_FLAGS


### PR DESCRIPTION
semantic-release runs 'gem build appmap.gemspec', not 'rake gem:build',
so the customization that was running yarn install --prod during the
rake task wasn't actually getting called when releases were made.

The result was missing node_modules, and the rake tasks that depend on
the NodeJS code were broken.