### PR TITLE
feat: Show config file name in validation messages

### DIFF
--- a/lib/appmap/service/validator/config_validator.rb
+++ b/lib/appmap/service/validator/config_validator.rb
@@ -39,7 +39,7 @@ module AppMap
         rescue Psych::SyntaxError => e
           @violations << Violation.error(
             filename: @config_file,
-            message: 'AppMap configuration is not valid YAML',
+            message: "AppMap configuration #{@config_file} is not valid YAML",
             detailed_message: e.message
           )
           nil
@@ -52,7 +52,7 @@ module AppMap
         rescue StandardError => e
           @violations << Violation.error(
             filename: @config_file,
-            message: 'AppMap configuration could not be loaded',
+            message: "AppMap configuration #{@config_file} could not be loaded",
             detailed_message: e.message
           )
           nil
@@ -62,7 +62,7 @@ module AppMap
           unless present?
             @violations << Violation.error(
               filename: @config_file,
-              message: 'AppMap configuration file does not exist'
+              message: "AppMap configuration #{@config_file} file does not exist"
             )
           end
         end

--- a/test/agent_setup_validate_test.rb
+++ b/test/agent_setup_validate_test.rb
@@ -30,7 +30,7 @@ class AgentSetupValidateTest < Minitest::Test
       {
         level: :error,
         filename: NON_EXISTING_CONFIG_FILENAME,
-        message: 'AppMap configuration file does not exist'
+        message: "AppMap configuration #{NON_EXISTING_CONFIG_FILENAME} file does not exist"
       }
     ])
     assert_equal expected, output.strip
@@ -47,7 +47,7 @@ class AgentSetupValidateTest < Minitest::Test
       {
         level: :error,
         filename: INVALID_YAML_CONFIG_FILENAME,
-        message: 'AppMap configuration is not valid YAML',
+        message: "AppMap configuration #{INVALID_YAML_CONFIG_FILENAME} is not valid YAML",
         detailed_message: "(#{INVALID_YAML_CONFIG_FILENAME}): " \
           'did not find expected key while parsing a block mapping at line 1 column 1'
       }
@@ -66,7 +66,7 @@ class AgentSetupValidateTest < Minitest::Test
       {
         level: :error,
         filename: INVALID_CONFIG_FILENAME,
-        message: 'AppMap configuration could not be loaded',
+        message: "AppMap configuration #{INVALID_CONFIG_FILENAME} could not be loaded",
         detailed_message: "no implicit conversion of String into Integer"
       }
     ])


### PR DESCRIPTION
Interpolate the config file name in the validation messages. This allows
them to be displayed directly to the user, without requiring any
additional processing.