### PR TITLE
feat: Builtin code such as Ruby Logger can be hooked via appmap.yml

### DIFF
--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -117,13 +117,14 @@ module AppMap
     # entry in appmap.yml. When the Config is initialized, each Function is converted into
     # a Package and TargetMethods. It's called a Function rather than a Method, because Function
     # is the AppMap terminology.
-    Function = Struct.new(:package, :cls, :labels, :function_names) do # :nodoc:
+    Function = Struct.new(:package, :cls, :labels, :function_names, :builtin) do # :nodoc:
       def to_h
         {
           package: package,
           class: cls,
           labels: labels,
-          functions: function_names.map(&:to_sym)
+          functions: function_names.map(&:to_sym),
+          builtin: builtin
         }.compact
       end
     end
@@ -244,7 +245,7 @@ module AppMap
       @depends_config = depends_config
       @hook_paths = Set.new(packages.map(&:path))
       @exclude = exclude
-      @builtin_hooks = BUILTIN_HOOKS
+      @builtin_hooks = BUILTIN_HOOKS.dup
       @functions = functions
 
       @hooked_methods = METHOD_HOOKS.each_with_object(Hash.new { |h,k| h[k] = [] }) do |cls_target_methods, hooked_methods|
@@ -254,7 +255,14 @@ module AppMap
       functions.each do |func|
         package_options = {}
         package_options[:labels] = func.labels if func.labels
-        @hooked_methods[func.cls] << TargetMethods.new(func.function_names, Package.build_from_path(func.package, **package_options))
+        package_options[:package_name] = func.package if func.builtin
+        hook = TargetMethods.new(func.function_names, Package.build_from_path(func.package, **package_options))
+        if func.builtin
+          @builtin_hooks[func.cls] ||= []
+          @builtin_hooks[func.cls] << hook
+        else
+          @hooked_methods[func.cls] << hook
+        end
       end
 
       @hooked_methods.each_value do |hooks|
@@ -300,6 +308,7 @@ module AppMap
           MISSING_FILE_MSG
           {}
         end
+
         load(config_data).tap do |config|
           config_yaml = {
             'name' => config.name,
@@ -324,15 +333,22 @@ module AppMap
 
         if config_data['functions']
           config_params[:functions] = config_data['functions'].map do |function_data|
-            package = function_data['package']
-            cls = function_data['class']
-            functions = function_data['function'] || function_data['functions']
-            raise %q(AppMap config 'function' element should specify 'package', 'class' and 'function' or 'functions') unless package && cls && functions
+            function_name = function_data['name']
+            package, cls, functions = []
+            if function_name
+              package, cls, _, function = Util.parse_function_name(function_name)
+              functions = Array(function)
+            else
+              package = function_data['package']
+              cls = function_data['class']
+              functions = function_data['function'] || function_data['functions']
+              raise %q(AppMap config 'function' element should specify 'package', 'class' and 'function' or 'functions') unless package && cls && functions
+            end
 
             functions = Array(functions).map(&:to_sym)
             labels = function_data['label'] || function_data['labels']
             labels = Array(labels).map(&:to_s) if labels
-            Function.new(package, cls, labels, functions)
+            Function.new(package, cls, labels, functions, function_data['builtin'])
           end
         end
 

--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -117,10 +117,11 @@ module AppMap
     # entry in appmap.yml. When the Config is initialized, each Function is converted into
     # a Package and TargetMethods. It's called a Function rather than a Method, because Function
     # is the AppMap terminology.
-    Function = Struct.new(:package, :cls, :labels, :function_names, :builtin) do # :nodoc:
+    Function = Struct.new(:package, :cls, :labels, :function_names, :builtin, :package_name) do # :nodoc:
       def to_h
         {
           package: package,
+          package_name: package_name,
           class: cls,
           labels: labels,
           functions: function_names.map(&:to_sym),
@@ -255,7 +256,8 @@ module AppMap
       functions.each do |func|
         package_options = {}
         package_options[:labels] = func.labels if func.labels
-        package_options[:package_name] = func.package if func.builtin
+        package_options[:package_name] = func.package_name
+        package_options[:package_name] ||= func.package if func.builtin
         hook = TargetMethods.new(func.function_names, Package.build_from_path(func.package, **package_options))
         if func.builtin
           @builtin_hooks[func.cls] ||= []
@@ -348,7 +350,7 @@ module AppMap
             functions = Array(functions).map(&:to_sym)
             labels = function_data['label'] || function_data['labels']
             labels = Array(labels).map(&:to_s) if labels
-            Function.new(package, cls, labels, functions, function_data['builtin'])
+            Function.new(package, cls, labels, functions, function_data['builtin'], function_data['require'])
           end
         end
 

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -89,7 +89,7 @@ module AppMap
 
       config.builtin_hooks.each do |class_name, hooks|
         Array(hooks).each do |hook|
-          require hook.package.package_name if hook.package.package_name
+          require hook.package.package_name if hook.package.package_name && hook.package.package_name != 'ruby'
           Array(hook.method_names).each do |method_name|
             method_name = method_name.to_sym
             base_cls = class_from_string.(class_name)

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -23,13 +23,12 @@ module AppMap
     class << self
       def parse_function_name(name)
         package_tokens = name.split('/')
-        raise "Malformed fully-qualified function name #{name}" if package_tokens.length < 2
 
         class_and_name = package_tokens.pop
         class_name, function_name, static = class_and_name.include?('.') ? class_and_name.split('.', 2) + [ true ] : class_and_name.split('#', 2) + [ false ]
 
         raise "Malformed fully-qualified function name #{name}" unless function_name
-        [ package_tokens.join('/'), class_name, static, function_name ]
+        [ package_tokens.empty? ? 'ruby' : package_tokens.join('/'), class_name, static, function_name ]
       end
 
       # scenario_filename builds a suitable file name from a scenario name.

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -21,6 +21,17 @@ module AppMap
     WHITE   = "\e[37m"
 
     class << self
+      def parse_function_name(name)
+        package_tokens = name.split('/')
+        raise "Malformed fully-qualified function name #{name}" if package_tokens.length < 2
+
+        class_and_name = package_tokens.pop
+        class_name, function_name, static = class_and_name.include?('.') ? class_and_name.split('.', 2) + [ true ] : class_and_name.split('#', 2) + [ false ]
+
+        raise "Malformed fully-qualified function name #{name}" unless function_name
+        [ package_tokens.join('/'), class_name, static, function_name ]
+      end
+
       # scenario_filename builds a suitable file name from a scenario name.
       # Special characters are removed, and the file name is truncated to fit within
       # shell limitations.

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -55,6 +55,34 @@ describe AppMap::Config, docker: false do
     expect(config.to_h.deep_stringify_keys!).to eq(config_expectation)
   end
 
+  it 'interprets a function in canonical name format' do
+    config_data = {
+      name: 'test',
+      packages: [],
+      functions: [
+        {
+          name: 'pkg/cls#fn',
+        }
+      ]
+    }.deep_stringify_keys!
+    config = AppMap::Config.load(config_data)
+
+    config_expectation = {
+      exclude: [],
+      name: 'test',
+      packages: [],
+      functions: [
+        {
+          package: 'pkg',
+          class: 'cls',
+          functions: [ :fn ],
+        }
+      ]
+    }.deep_stringify_keys!
+
+    expect(config.to_h.deep_stringify_keys!).to eq(config_expectation)
+  end
+
   context do
     let(:warnings) { @warnings ||= [] }
     let(:warning) { warnings.join }

--- a/spec/fixtures/depends/revoke_api_key.appmap.json
+++ b/spec/fixtures/depends/revoke_api_key.appmap.json
@@ -74,7 +74,7 @@
       {
         "appmap_digest": "7fecdd763d47626364364da02387f1fcbfe805123e806f08bacde96636cfc91d",
         "canonicalization_algorithm": "info",
-        "digest": "a34db849f603f8e60163d43f0b736629335d2bdc9e9d092118e4d16a8881efc3",
+        "digest": "bd63ed674a87494c9565d4bf7ecad797683528b8b83bbb66f27b334b6e303f67",
         "fingerprint_algorithm": "sha256"
       },
       {
@@ -110,13 +110,13 @@
       {
         "appmap_digest": "7fecdd763d47626364364da02387f1fcbfe805123e806f08bacde96636cfc91d",
         "canonicalization_algorithm": "trace",
-        "digest": "635c00a9c9a076bd394f905aaffc131b6c1d88a6a0a61de189b94085dc9efcc8",
+        "digest": "464056ee79400cf881d31e4db167cf12caadfffdc814bc89ed01b89f746dcbd1",
         "fingerprint_algorithm": "sha256"
       },
       {
         "appmap_digest": "7fecdd763d47626364364da02387f1fcbfe805123e806f08bacde96636cfc91d",
         "canonicalization_algorithm": "update",
-        "digest": "558e505358d7dbb079b380badec078da41a39dc7c3f5aa80e17b2b278a22b1b7",
+        "digest": "a78760f0ae6eabb20403b812101d86c609294e36fff53be54dec71b1244076b0",
         "fingerprint_algorithm": "sha256"
       }
     ]

--- a/spec/fixtures/depends/user_page_scenario.appmap.json
+++ b/spec/fixtures/depends/user_page_scenario.appmap.json
@@ -68,7 +68,7 @@
       {
         "appmap_digest": "4a2f6e28befc256c3cdc3ad05f3e51156e0fb805300f095a74f7719cc2bcb650",
         "canonicalization_algorithm": "info",
-        "digest": "5c4a971b40385f7b3b5fc4c0fea57549fd8c6897c162ec78094dddfdc8ed0667",
+        "digest": "e09798c3872822cd6aee88e0de2b54d06e05bf1f4c1bb3c21ca5d422e1938980",
         "fingerprint_algorithm": "sha256"
       },
       {
@@ -104,13 +104,13 @@
       {
         "appmap_digest": "4a2f6e28befc256c3cdc3ad05f3e51156e0fb805300f095a74f7719cc2bcb650",
         "canonicalization_algorithm": "trace",
-        "digest": "c03e70cd074fdcd3ca2c87a841039e235e4d82ab430ccaa16220e33a69f1124f",
+        "digest": "5bccf2aaf6b511d84e297cd882d998927bfdcfb24b2baa63c897a87ab08878cd",
         "fingerprint_algorithm": "sha256"
       },
       {
         "appmap_digest": "4a2f6e28befc256c3cdc3ad05f3e51156e0fb805300f095a74f7719cc2bcb650",
         "canonicalization_algorithm": "update",
-        "digest": "1dc97bab5018e8a9c09eae4fd66afa778a109544a54b89644eb15da2d140ed84",
+        "digest": "2ab423434b33202dc6d67a42db9249a87ad52b4dec60489a996eb8400cd410da",
         "fingerprint_algorithm": "sha256"
       }
     ]

--- a/spec/fixtures/rails5_users_app/appmap.yml
+++ b/spec/fixtures/rails5_users_app/appmap.yml
@@ -5,3 +5,7 @@ packages:
   - path: app/controllers
     labels: [ mvc.controller ]
   - gem: sequel
+functions:
+  - name: logger/Logger::LogDevice#write
+    builtin: true
+    label: log

--- a/spec/fixtures/rails6_users_app/appmap.yml
+++ b/spec/fixtures/rails6_users_app/appmap.yml
@@ -5,6 +5,10 @@ packages:
   - path: app/controllers
     labels: [ mvc.controller ]
   - gem: sequel
+functions:
+  - name: logger/Logger::LogDevice#write
+    builtin: true
+    label: log
 swagger:
   project_version: 1.1.0
   output_dir: tmp/swagger

--- a/spec/rails_recording_spec.rb
+++ b/spec/rails_recording_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_spec_helper'
 
+def default_rails_versions
+  ruby_2? ? [ 5, 6 ] : [ 6 ]
+end
+
 # Rails5 doesn't work with Ruby 3.x
-RailsVersions = ruby_2? ? [ 5, 6 ] : [ 6 ]
+RailsVersions = ENV['RAILS_VERSIONS'] || default_rails_versions
 
 describe 'Rails' do
   RailsVersions.each do |rails_major_version| # rubocop:disable Metrics/BlockLength
@@ -88,6 +92,15 @@ describe 'Rails' do
               'thread_id' => Integer,
               'parent_id' => Integer,
               'elapsed' => Numeric
+            )
+          end
+
+          it 'captures log events' do
+            expect(events).to include hash_including(
+              'event' => 'call',
+              'defined_class' => 'Logger::LogDevice',
+              'method_id' => 'write',
+              'static' => false
             )
           end
 


### PR DESCRIPTION
Add a config line in the functions section such as this:

```
- name: logger/Logger#add
  builtin: true
  label: log
```

Note that the 'name' syntax  with the fully-qualified function name is
also a new addition in this commit.