### PR TITLE
fix: Fix compilation on macOS with Xcode 13

### DIFF
--- a/ext/appmap/extconf.rb
+++ b/ext/appmap/extconf.rb
@@ -1,6 +1,17 @@
 require "mkmf"
 
+
 $CFLAGS='-Werror'
+
+# Per https://bugs.ruby-lang.org/issues/17865,
+# compound-token-split-by-macro was added in clang 12 and broke
+# compilation with some of the ruby headers. If the current compiler
+# supports the new warning, turn it off.
+new_warning = '-Wno-error=compound-token-split-by-macro'
+if try_cflags(new_warning)
+  $CFLAGS += ' ' + new_warning
+end
+
 extension_name = "appmap"
 dir_config(extension_name)
 create_makefile(File.join(extension_name, extension_name))


### PR DESCRIPTION
Xcode 13* introduces a new warning named compound-token-split-by-macro.
One of the ruby headers triggers this warning. We build our extension
with -Werror in CFLAGS, resulting in the issue described here:
https://bugs.ruby-lang.org/issues/17865 .

This doesn't appear to be a bug in the ruby header, so it seems safe to
ignore it until it's fixed. This change keeps -Werror in CFLAGS, and
just disables compound-token-split-by-macro.

* The issue indicates this behavior was actually introduced in clang 12, which
was probably part of Xcode 12.