### PR TITLE
test: Fix argument for Depends API smoke test

### DIFF
--- a/lib/appmap/command/inspect.rb
+++ b/lib/appmap/command/inspect.rb
@@ -13,7 +13,6 @@ module AppMap
 
       def inspect(arguments)
         detect_nodejs
-        index_appmaps
 
         arguments.unshift 'inspect'
         arguments.unshift APPMAP_JS

--- a/spec/depends/api_spec.rb
+++ b/spec/depends/api_spec.rb
@@ -104,7 +104,7 @@ describe 'Depends API' do
   describe '.run_tests' do
     def run_tests
       Dir.chdir 'spec/fixtures/depends' do
-        api.run_tests([ 'spec/actual_rspec_test.rb', 'test/actual_minitest_test.rb' ], appmap_dir: Pathname.new(DEPENDS_TEST_DIR).expand_path.to_s)
+        api.run_tests([ 'spec/actual_rspec_test.rb', 'test/actual_minitest_test.rb' ], appmap_dir: Pathname.new('.').expand_path.to_s)
       end
     end
 


### PR DESCRIPTION
Pass the correct directory to --appmap-dir when running the Depends API
smoke test.

Using the incorrect directory causes a Promise rejection, which results this warning in Node 14:
```
stderr: Fingerprinting appmaps in /Users/ajp/src/applandinc/appmap-ruby/spec/fixtures/depends/spec/fixtures/depends
stderr: Scanning /Users/ajp/src/applandinc/appmap-ruby/spec/fixtures/depends/spec/fixtures/depends for AppMaps
stderr: (node:41934) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, scandir '/Users/ajp/src/applandinc/appmap-ruby/spec/fixtures/depends/spec/fixtures/depends'
stderr:     at emitUnhandledRejectionWarning (internal/process/promises.js:168:15)
stderr:     at processPromiseRejections (internal/process/promises.js:247:11)
stderr:     at processTicksAndRejections (internal/process/task_queues.js:96:32)
stderr: (node:41934) Error: ENOENT: no such file or directory, scandir '/Users/ajp/src/applandinc/appmap-ruby/spec/fixtures/depends/spec/fixtures/depends'
stderr: (node:41934) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
stderr:     at emitDeprecationWarning (internal/process/promises.js:180:11)
stderr:     at processPromiseRejections (internal/process/promises.js:249:13)
stderr:     at processTicksAndRejections (internal/process/task_queues.js:96:32)
```
`nvm install --lts` is now installing Node 16, which follows through on the threat: Promise rejections now cause Node.js to exit with a non-zero exit code.