### PR TITLE
feat: Externalize hooks config

### DIFF
--- a/lib/appmap/builtin_hooks/json.yml
+++ b/lib/appmap/builtin_hooks/json.yml
@@ -1,0 +1,4 @@
+- method: JSON::Ext::Parser#parse
+  label: format.json.parse
+- method: JSON::Ext::Generator::State#generate
+  label: format.json.generate

--- a/lib/appmap/builtin_hooks/net/http.yml
+++ b/lib/appmap/builtin_hooks/net/http.yml
@@ -1,0 +1,3 @@
+- method: Net::HTTP#request
+  label: protocol.http
+  handler_class: AppMap::Handler::NetHTTP

--- a/lib/appmap/builtin_hooks/openssl.yml
+++ b/lib/appmap/builtin_hooks/openssl.yml
@@ -1,0 +1,16 @@
+- method: OpenSSL::PKey::PKey#sign
+  label: crypto.pkey
+- methods:
+  - OpenSSL::X509::Request#sign
+  - OpenSSL::X509::Request#verify
+  label: crypto.x509
+- method: OpenSSL::X509::Certificate#sign
+  label: crypto.x509
+- methods:
+  - OpenSSL::PKCS5#pbkdf2_hmac
+  - OpenSSL::PKCS5#pbkdf2_hmac_sha1
+  label: crypto.pkcs5
+- method: OpenSSL::Cipher#encrypt
+  label: crypto.encrypt
+- method: OpenSSL::Cipher#decrypt
+  label: crypto.decrypt

--- a/lib/appmap/builtin_hooks/yaml.yml
+++ b/lib/appmap/builtin_hooks/yaml.yml
@@ -1,0 +1,10 @@
+- methods:
+  - Psych#load
+  - Psych#load_stream
+  - Psych#parse
+  - Psych#parse_stream
+  label: format.yaml.parse
+- methods:
+  - Psych#dump
+  - Psych#dump_stream
+  label: format.yaml.generate

--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -11,10 +11,12 @@ require 'appmap/depends/configuration'
 
 module AppMap
   class Config
-    # Specifies a code +path+ to be mapped.
+    # Specifies a logical code package be mapped.
+    # This can be a project source folder, a Gem, or a builtin.
     #
     # Options:
     #
+    # * +path+ indicates a relative path to a code folder.
     # * +gem+ may indicate a gem name that "owns" the path
     # * +require_name+ can be used to make sure that the code is required so that it can be loaded. This is generally used with
     #   builtins, or when the path to be required is not automatically required when bundler requires the gem.
@@ -22,7 +24,7 @@ module AppMap
     # * +labels+ is used to apply labels to matching code. This is really only useful when the package will be applied to
     #   specific functions, via TargetMethods.
     # * +shallow+ indicates shallow mapping, in which only the entrypoint to a gem is recorded.
-    Package = Struct.new(:path, :gem, :require_name, :exclude, :labels, :shallow) do
+    Package = Struct.new(:name, :path, :gem, :require_name, :exclude, :labels, :shallow) do
       # This is for internal use only.
       private_methods :gem
 
@@ -45,7 +47,7 @@ module AppMap
         # Builds a package for a path, such as `app/models` in a Rails app. Generally corresponds to a `path:` entry
         # in appmap.yml. Also used for mapping specific methods via TargetMethods.
         def build_from_path(path, shallow: false, require_name: nil, exclude: [], labels: [])
-          Package.new(path, nil, require_name, exclude, labels, shallow)
+          Package.new(path, path, nil, require_name, exclude, labels, shallow)
         end
 
         # Builds a package for gem. Generally corresponds to a `gem:` entry in appmap.yml. Also used when mapping
@@ -57,7 +59,7 @@ module AppMap
           end
           path = gem_path(gem, optional)
           if path
-            Package.new(path, gem, require_name, exclude, labels, shallow)
+            Package.new(gem, path, gem, require_name, exclude, labels, shallow)
           else
             AppMap::Util.startup_message "#{gem} is not available in the bundle"
           end
@@ -75,19 +77,16 @@ module AppMap
         end
       end
 
-      def name
-        gem || path
-      end
-
       def to_h
         {
+          name: name,
           path: path,
-          require_name: require_name,
           gem: gem,
-          handler_class: handler_class.name,
+          require_name: require_name,
+          handler_class: handler_class ? handler_class.name : nil,
           exclude: Util.blank?(exclude) ? nil : exclude,
           labels: Util.blank?(labels) ? nil : labels,
-          shallow: shallow
+          shallow: shallow.nil? ? nil : shallow,
         }.compact
       end
     end
@@ -97,12 +96,12 @@ module AppMap
       attr_reader :method_names, :package
 
       def initialize(method_names, package)
-        @method_names = method_names
+        @method_names = Array(method_names).map(&:to_sym)
         @package = package
       end
 
       def include_method?(method_name)
-        Array(method_names).include?(method_name)
+        method_names.include?(method_name.to_sym)
       end
 
       def to_h
@@ -139,9 +138,13 @@ module AppMap
     private_constant :MethodHook
     
     class << self
-      def package_hooks(gem_name, methods, handler_class: nil, require_name: nil)
+      def package_hooks(methods, path: nil, gem: nil, force: false, handler_class: nil, require_name: nil)
         Array(methods).map do |method|
-          package = Package.build_from_gem(gem_name, require_name: require_name, labels: method.labels, shallow: false, optional: true)
+          package = if gem
+            Package.build_from_gem(gem, require_name: require_name, labels: method.labels, shallow: false, force: force, optional: true)
+          elsif path
+            Package.build_from_path(path, require_name: require_name, labels: method.labels, shallow: false)
+          end
           next unless package
 
           package.handler_class = handler_class if handler_class
@@ -152,85 +155,63 @@ module AppMap
       def method_hook(cls, method_names, labels)
         MethodHook.new(cls, method_names, labels)
       end
+
+      def declare_hook(hook_decl)
+        hook_decl = YAML.load(hook_decl) if hook_decl.is_a?(String)
+        
+        methods_decl = hook_decl['methods'] || hook_decl['method']
+        methods_decl = Array(methods_decl) unless methods_decl.is_a?(Hash)
+        labels_decl = Array(hook_decl['labels'] || hook_decl['label'])
+
+        methods = methods_decl.map do |name|
+          class_name, method_name, static = name.include?('.') ? name.split('.', 2) + [ true ] : name.split('#', 2) + [ false ]
+          method_hook class_name, [ method_name ], labels_decl
+        end
+
+        require_name = hook_decl['require_name']
+        gem_name = hook_decl['gem']
+        path = hook_decl['path']
+
+        options = {
+          gem: gem_name,
+          path: path,
+          require_name: require_name || gem_name || path,
+          force: hook_decl['force']
+        }.compact
+
+        handler_class = hook_decl['handler_class']
+        options[:handler_class] = Util::class_from_string(handler_class) if handler_class
+        
+        package_hooks(methods, **options)
+      end
+
+      def load_builtin_hooks
+        load_hooks('builtin_hooks') do |path, config|
+          config['path'] = path
+        end
+      end
+
+      def load_gem_hooks
+        load_hooks('gem_hooks') do |path, config|
+          config['gem'] = path
+        end
+      end
+
+      def load_hooks(dir, &block)
+        basedir = [ __dir__, dir ].join('/')
+        [].tap do |hooks|
+          Dir.glob("#{basedir}/**/*.yml").each do |yaml_file|
+            path = yaml_file[basedir.length + 1...-4]
+            YAML.load(File.read(yaml_file)).map do |config|
+              yield path, config
+              config
+            end.each do |config|
+              hooks << declare_hook(config)
+            end
+          end
+        end.compact.flatten
+      end
     end
-
-    # Hook well-known functions. When a function configured here is available in the bundle, it will be hooked with the
-    # predefined labels specified here. If any of these hooks are not desired, they can be disabled in the +exclude+ section
-    # of appmap.yml.
-    METHOD_HOOKS = [
-      package_hooks('actionview',
-        [
-          method_hook('ActionView::Renderer', :render, %w[mvc.view]),
-          method_hook('ActionView::TemplateRenderer', :render, %w[mvc.view]),
-          method_hook('ActionView::PartialRenderer', :render, %w[mvc.view])
-        ],
-        handler_class: AppMap::Handler::Rails::Template::RenderHandler,
-        require_name: 'action_view'
-      ),
-      package_hooks('actionview',
-        [
-          method_hook('ActionView::Resolver', %i[find_all find_all_anywhere], %w[mvc.template.resolver])
-        ],
-        handler_class: AppMap::Handler::Rails::Template::ResolverHandler,
-        require_name: 'action_view'
-      ),
-      package_hooks('actionpack',
-        [
-          method_hook('ActionDispatch::Request::Session', %i[[] dig values fetch], %w[http.session.read]),
-          method_hook('ActionDispatch::Request::Session', %i[destroy []= clear update delete merge], %w[http.session.write]),
-          method_hook('ActionDispatch::Cookies::CookieJar', %i[[] fetch], %w[http.session.read]),
-          method_hook('ActionDispatch::Cookies::CookieJar', %i[[]= clear update delete recycle], %w[http.session.write]),
-          method_hook('ActionDispatch::Cookies::EncryptedCookieJar', %i[[]= clear update delete recycle], %w[http.cookie crypto.encrypt])
-        ],
-        require_name: 'action_dispatch'
-      ),
-      package_hooks('cancancan',
-        [
-          method_hook('CanCan::ControllerAdditions', %i[authorize! can? cannot?], %w[security.authorization]),
-          method_hook('CanCan::Ability', %i[authorize?], %w[security.authorization])
-        ]
-      ),
-      package_hooks('actionpack',
-        [
-          method_hook('ActionController::Instrumentation', %i[process_action send_file send_data redirect_to], %w[mvc.controller])
-        ],
-        require_name: 'action_controller'
-      )
-    ].flatten.freeze
-
-    OPENSSL_PACKAGES = ->(labels) { Package.build_from_path('openssl', require_name: 'openssl', labels: labels) }
-
-    # Hook functions which are builtin to Ruby. Because they are builtins, they may be loaded before appmap.
-    # Therefore, we can't rely on TracePoint to report the loading of this code.
-    BUILTIN_HOOKS = {
-      'OpenSSL::PKey::PKey' => TargetMethods.new(:sign, OPENSSL_PACKAGES.(%w[crypto.pkey])),
-      'OpenSSL::X509::Request' => TargetMethods.new(%i[sign verify], OPENSSL_PACKAGES.(%w[crypto.x509])),
-      'OpenSSL::PKCS5' => TargetMethods.new(%i[pbkdf2_hmac_sha1 pbkdf2_hmac], OPENSSL_PACKAGES.(%w[crypto.pkcs5])),
-      'OpenSSL::Cipher' => [
-        TargetMethods.new(%i[encrypt], OPENSSL_PACKAGES.(%w[crypto.encrypt])),
-        TargetMethods.new(%i[decrypt], OPENSSL_PACKAGES.(%w[crypto.decrypt]))
-      ],
-      'ActiveSupport::Callbacks::CallbackSequence' => [
-        TargetMethods.new(:invoke_before, Package.build_from_gem('activesupport', force: true, require_name: 'active_support', labels: %w[mvc.before_action])),
-        TargetMethods.new(:invoke_after, Package.build_from_gem('activesupport', force: true, require_name: 'active_support', labels: %w[mvc.after_action])),
-      ],
-      'ActiveSupport::SecurityUtils' => TargetMethods.new(:secure_compare, Package.build_from_gem('activesupport', force: true, require_name: 'active_support/security_utils', labels: %w[crypto.secure_compare])),
-      'OpenSSL::X509::Certificate' => TargetMethods.new(:sign, OPENSSL_PACKAGES.(%w[crypto.x509])),
-      'Net::HTTP' => TargetMethods.new(:request, Package.build_from_path('net/http', require_name: 'net/http', labels: %w[protocol.http]).tap do |package|
-        package.handler_class = AppMap::Handler::NetHTTP
-      end),
-      'Net::SMTP' => TargetMethods.new(:send, Package.build_from_path('net/smtp', require_name: 'net/smtp', labels: %w[protocol.email.smtp])),
-      'Net::POP3' => TargetMethods.new(:mails, Package.build_from_path('net/pop3', require_name: 'net/pop', labels: %w[protocol.email.pop])),
-      # This is happening: Method send_command not found on Net::IMAP
-      # 'Net::IMAP' => TargetMethods.new(:send_command, Package.build_from_path('net/imap', require_name: 'net/imap', labels: %w[protocol.email.imap])),
-      # 'Marshal' => TargetMethods.new(%i[dump load], Package.build_from_path('marshal', labels: %w[format.marshal])),
-      'Psych' => [
-        TargetMethods.new(%i[load load_stream parse parse_stream], Package.build_from_path('yaml', require_name: 'psych', labels: %w[format.yaml.parse])),
-        TargetMethods.new(%i[dump dump_stream], Package.build_from_path('yaml', require_name: 'psych', labels: %w[format.yaml.generate])),
-      ],
-      'JSON::Ext::Parser' => TargetMethods.new(:parse, Package.build_from_path('json', require_name: 'json', labels: %w[format.json.parse])),
-      'JSON::Ext::Generator::State' => TargetMethods.new(:generate, Package.build_from_path('json', require_name: 'json', labels: %w[format.json.generate])),
-    }.freeze
 
     attr_reader :name, :appmap_dir, :packages, :exclude, :swagger_config, :depends_config, :hooked_methods, :builtin_hooks
 
@@ -247,10 +228,13 @@ module AppMap
       @depends_config = depends_config
       @hook_paths = Set.new(packages.map(&:path))
       @exclude = exclude
-      @builtin_hooks = BUILTIN_HOOKS.dup
       @functions = functions
 
-      @hooked_methods = METHOD_HOOKS.each_with_object(Hash.new { |h,k| h[k] = [] }) do |cls_target_methods, hooked_methods|
+      @builtin_hooks = self.class.load_builtin_hooks.each_with_object(Hash.new { |h,k| h[k] = [] }) do |cls_target_methods, hooked_methods|
+        hooked_methods[cls_target_methods.cls] << cls_target_methods.target_methods
+      end
+
+      @hooked_methods = self.class.load_gem_hooks.each_with_object(Hash.new { |h,k| h[k] = [] }) do |cls_target_methods, hooked_methods|
         hooked_methods[cls_target_methods.cls] << cls_target_methods.target_methods
       end
 
@@ -269,9 +253,7 @@ module AppMap
       end
 
       @hooked_methods.each_value do |hooks|
-        Array(hooks).each do |hook|
-          @hook_paths << hook.package.path
-        end
+        @hook_paths += Array(hooks).map { |hook| hook.package.path }.compact
       end
     end
 
@@ -422,8 +404,8 @@ module AppMap
 
       # Hook a method which is specified by class and method name.
       def package_for_code_object
-        Array(config.hooked_methods[cls.name])
-          .compact
+        class_name = cls.to_s.index('#<Class:') == 0 ? cls.to_s['#<Class:'.length...-1] : cls.name
+        Array(config.hooked_methods[class_name])
           .find { |hook| hook.include_method?(method.name) }
           &.package
       end

--- a/lib/appmap/event.rb
+++ b/lib/appmap/event.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'weakref'
+
 module AppMap
   module Event
     @@id_counter = 0

--- a/lib/appmap/gem_hooks/actionpack.yml
+++ b/lib/appmap/gem_hooks/actionpack.yml
@@ -1,0 +1,40 @@
+- methods:
+  - ActionDispatch::Request::Session#[]
+  - ActionDispatch::Request::Session#dig
+  - ActionDispatch::Request::Session#values
+  - ActionDispatch::Request::Session#fetch
+  - ActionDispatch::Cookies::CookieJar#[]
+  - ActionDispatch::Cookies::CookieJar#fetch
+  label: http.session.read
+  require_name: action_dispatch
+- methods:
+  - ActionDispatch::Request::Session#destroy
+  - ActionDispatch::Request::Session#[]=
+  - ActionDispatch::Request::Session#clear
+  - ActionDispatch::Request::Session#update
+  - ActionDispatch::Request::Session#delete
+  - ActionDispatch::Request::Session#merge
+  - ActionDispatch::Cookies::CookieJar#[]=
+  - ActionDispatch::Cookies::CookieJar#clear
+  - ActionDispatch::Cookies::CookieJar#update
+  - ActionDispatch::Cookies::CookieJar#delete
+  - ActionDispatch::Cookies::CookieJar#recycle!
+  label: http.session.write
+  require_name: action_dispatch
+- methods:
+  - ActionDispatch::Cookies::EncryptedCookieJar#[]=
+  - ActionDispatch::Cookies::EncryptedCookieJar#clear
+  - ActionDispatch::Cookies::EncryptedCookieJar#update
+  - ActionDispatch::Cookies::EncryptedCookieJar#delete
+  - ActionDispatch::Cookies::EncryptedCookieJar#recycle
+  labels:
+  - http.cookie
+  - crypto.encrypt
+  require_name: action_dispatch
+- methods:
+  - ActionController::Instrumentation#process_action
+  - ActionController::Instrumentation#send_file
+  - ActionController::Instrumentation#send_data
+  - ActionController::Instrumentation#redirect_to
+  label: mvc.controller
+  require_name: action_controller

--- a/lib/appmap/gem_hooks/actionview.yml
+++ b/lib/appmap/gem_hooks/actionview.yml
@@ -1,0 +1,13 @@
+- methods:
+  - ActionView::Renderer#render
+  - ActionView::TemplateRenderer#render
+  - ActionView::PartialRenderer#render
+  label: mvc.view
+  handler_class: AppMap::Handler::Rails::Template::RenderHandler
+  require_name: action_view
+- methods:
+  - ActionView::Resolver#find_all
+  - ActionView::Resolver#find_all_anywhere
+  label: mvc.template.resolver
+  handler_class: AppMap::Handler::Rails::Template::ResolverHandler
+  require_name: action_view

--- a/lib/appmap/gem_hooks/activesupport.yml
+++ b/lib/appmap/gem_hooks/activesupport.yml
@@ -1,0 +1,12 @@
+- method: ActiveSupport::Callbacks::CallbackSequence#invoke_before
+  label: mvc.before_action
+  require_name: active_support
+  force: true
+- method: ActiveSupport::Callbacks::CallbackSequence#invoke_after
+  label: mvc.after_action
+  require_name: active_support
+  force: true
+- method: ActiveSupport::SecurityUtils#secure_compare
+  label: crypto.secure_compare
+  require_name: active_support/security_utils
+  force: true

--- a/lib/appmap/gem_hooks/cancancan.yml
+++ b/lib/appmap/gem_hooks/cancancan.yml
@@ -1,0 +1,6 @@
+- methods:
+  - CanCan::ControllerAdditions#authorize!
+  - CanCan::ControllerAdditions#can?
+  - CanCan::ControllerAdditions#cannot?
+  - CanCan::Ability#authorize?
+  label: security.authorization

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -89,7 +89,8 @@ module AppMap
 
       config.builtin_hooks.each do |class_name, hooks|
         Array(hooks).each do |hook|
-          require hook.package.package_name if hook.package.package_name && hook.package.package_name != 'ruby'
+          require hook.package.require_name if hook.package.require_name && hook.package.require_name != 'ruby'
+
           Array(hook.method_names).each do |method_name|
             method_name = method_name.to_sym
             base_cls = class_from_string.(class_name)

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -128,7 +128,7 @@ module AppMap
       end
 
       hook_loaded_code.(config.builtin_hooks, true)
-      hook_loaded_code.(config.hooked_methods, false)
+      hook_loaded_code.(config.gem_hooks, false)
     end
 
     protected

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -21,6 +21,14 @@ module AppMap
     WHITE   = "\e[37m"
 
     class << self
+      def class_from_string(fq_class, must: true)
+        fq_class.split('::').inject(Object) do |mod, class_name|
+          mod.const_get(class_name)
+        end
+      rescue NameError
+        raise if must
+      end
+
       def parse_function_name(name)
         package_tokens = name.split('/')
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -33,10 +33,12 @@ describe AppMap::Config, docker: false do
       name: 'test',
       packages: [
         {
+          name: 'path-1',
           path: 'path-1',
           handler_class: 'AppMap::Handler::Function'
         },
         {
+          name: 'path-2',
           path: 'path-2',
           handler_class: 'AppMap::Handler::Function',
           exclude: [ 'exclude-1' ]
@@ -94,7 +96,8 @@ describe AppMap::Config, docker: false do
       expect(config.to_h).to eq(YAML.load(<<~CONFIG))
       :name: appmap-ruby
       :packages:
-      - :path: lib
+      - :name: lib
+        :path: lib
         :handler_class: AppMap::Handler::Function
         :shallow: false
       :functions: []

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -4,60 +4,7 @@ require 'rails_spec_helper'
 require 'appmap/config'
 
 describe AppMap::Config, docker: false do
-  it 'loads from a Hash' do
-    config_data = {
-      exclude: [],
-      name: 'test',
-      packages: [
-        {
-          path: 'path-1'
-        },
-        {
-          path: 'path-2',
-          exclude: [ 'exclude-1' ]
-        }
-      ],
-      functions: [
-        {
-          package: 'pkg',
-          class: 'cls',
-          function: 'fn',
-          label: 'lbl'
-        }
-      ]
-    }.deep_stringify_keys!
-    config = AppMap::Config.load(config_data)
-
-    config_expectation = {
-      exclude: [],
-      name: 'test',
-      packages: [
-        {
-          name: 'path-1',
-          path: 'path-1',
-          handler_class: 'AppMap::Handler::Function'
-        },
-        {
-          name: 'path-2',
-          path: 'path-2',
-          handler_class: 'AppMap::Handler::Function',
-          exclude: [ 'exclude-1' ]
-        }
-      ],
-      functions: [
-        {
-          package: 'pkg',
-          class: 'cls',
-          functions: [ :fn ],
-          labels: ['lbl']
-        }
-      ]
-    }.deep_stringify_keys!
-
-    expect(config.to_h.deep_stringify_keys!).to eq(config_expectation)
-  end
-
-  it 'interprets a function in canonical name format' do
+  it 'loads as expected' do
     config_data = {
       name: 'test',
       packages: [],
@@ -69,20 +16,212 @@ describe AppMap::Config, docker: false do
     }.deep_stringify_keys!
     config = AppMap::Config.load(config_data)
 
-    config_expectation = {
-      exclude: [],
-      name: 'test',
-      packages: [],
-      functions: [
+    expect(JSON.parse(JSON.generate(config.as_json))).to eq(JSON.parse(<<~FIXTURE))
+    {
+      "name": "test",
+      "appmap_dir": "tmp/appmap",
+      "packages": [
+      ],
+      "swagger_config": {
+        "project_name": null,
+        "project_version": "1.0",
+        "output_dir": "swagger",
+        "description": "Generate Swagger from AppMaps"
+      },
+      "depends_config": {
+        "base_dir": null,
+        "base_branches": [
+          "remotes/origin/main",
+          "remotes/origin/master"
+        ],
+        "test_file_patterns": [
+          "spec/**/*_spec.rb",
+          "test/**/*_test.rb"
+        ],
+        "dependent_tasks": [
+          "swagger"
+        ],
+        "description": "Bring AppMaps up to date with local file modifications, and updated derived data such as Swagger files",
+        "rspec_environment_method": "AppMap::Depends.test_env",
+        "minitest_environment_method": "AppMap::Depends.test_env",
+        "rspec_select_tests_method": "AppMap::Depends.select_rspec_tests",
+        "minitest_select_tests_method": "AppMap::Depends.select_minitest_tests",
+        "rspec_test_command_method": "AppMap::Depends.rspec_test_command",
+        "minitest_test_command_method": "AppMap::Depends.minitest_test_command"
+      },
+      "hook_paths": [
+        "pkg",
+        "#{Gem.loaded_specs['activesupport'].gem_dir}"
+      ],
+      "exclude": [
+      ],
+      "functions": [
         {
-          package: 'pkg',
-          class: 'cls',
-          functions: [ :fn ],
+          "cls": "cls",
+          "target_methods": {
+            "package": "pkg",
+            "method_names": [
+              "fn"
+            ]
+          }
         }
-      ]
-    }.deep_stringify_keys!
-
-    expect(config.to_h.deep_stringify_keys!).to eq(config_expectation)
+      ],
+      "builtin_hooks": {
+        "JSON::Ext::Parser": [
+          {
+            "package": "json",
+            "method_names": [
+              "parse"
+            ]
+          }
+        ],
+        "JSON::Ext::Generator::State": [
+          {
+            "package": "json",
+            "method_names": [
+              "generate"
+            ]
+          }
+        ],
+        "Net::HTTP": [
+          {
+            "package": "net/http",
+            "method_names": [
+              "request"
+            ]
+          }
+        ],
+        "OpenSSL::PKey::PKey": [
+          {
+            "package": "openssl",
+            "method_names": [
+              "sign"
+            ]
+          }
+        ],
+        "OpenSSL::X509::Request": [
+          {
+            "package": "openssl",
+            "method_names": [
+              "sign"
+            ]
+          },
+          {
+            "package": "openssl",
+            "method_names": [
+              "verify"
+            ]
+          }
+        ],
+        "OpenSSL::X509::Certificate": [
+          {
+            "package": "openssl",
+            "method_names": [
+              "sign"
+            ]
+          }
+        ],
+        "OpenSSL::PKCS5": [
+          {
+            "package": "openssl",
+            "method_names": [
+              "pbkdf2_hmac"
+            ]
+          },
+          {
+            "package": "openssl",
+            "method_names": [
+              "pbkdf2_hmac_sha1"
+            ]
+          }
+        ],
+        "OpenSSL::Cipher": [
+          {
+            "package": "openssl",
+            "method_names": [
+              "encrypt"
+            ]
+          },
+          {
+            "package": "openssl",
+            "method_names": [
+              "decrypt"
+            ]
+          }
+        ],
+        "Psych": [
+          {
+            "package": "yaml",
+            "method_names": [
+              "load"
+            ]
+          },
+          {
+            "package": "yaml",
+            "method_names": [
+              "load_stream"
+            ]
+          },
+          {
+            "package": "yaml",
+            "method_names": [
+              "parse"
+            ]
+          },
+          {
+            "package": "yaml",
+            "method_names": [
+              "parse_stream"
+            ]
+          },
+          {
+            "package": "yaml",
+            "method_names": [
+              "dump"
+            ]
+          },
+          {
+            "package": "yaml",
+            "method_names": [
+              "dump_stream"
+            ]
+          }
+        ]
+      },
+      "gem_hooks": {
+        "cls": [
+          {
+            "package": "pkg",
+            "method_names": [
+              "fn"
+            ]
+          }
+        ],
+        "ActiveSupport::Callbacks::CallbackSequence": [
+          {
+            "package": "activesupport",
+            "method_names": [
+              "invoke_before"
+            ]
+          },
+          {
+            "package": "activesupport",
+            "method_names": [
+              "invoke_after"
+            ]
+          }
+        ],
+        "ActiveSupport::SecurityUtils": [
+          {
+            "package": "activesupport",
+            "method_names": [
+              "secure_compare"
+            ]
+          }
+        ]
+      }
+    }
+    FIXTURE
   end
 
   context do


### PR DESCRIPTION
Hooks that are builtin to appmap-ruby are now all moved to YAML files in `lib/appmap/builtin_hooks` and `lib/appmap/gem_hooks`. So, builtin Ruby library and gem hooks, with labels, can now be added without writing Ruby code.

Example: https://github.com/applandinc/appmap-ruby/pull/202/files#diff-6d12bf13835e3e35920437bd8ff7f9526d256b39ab1b31c3897141e9d8b5ec31R1

```yaml
- method: OpenSSL::PKey::PKey#sign
  label: crypto.pkey
- methods:
  - OpenSSL::X509::Request#sign
  - OpenSSL::X509::Request#verify
  label: crypto.x509
```

`builtin_hooks` is for anything that's part of Ruby itself. The reason builtins are treated differently than gems is that there's no Gem path available from bundler. `gem_hooks` is for Gems. Perhaps this distinction could be removed, but I didn't want to bite that off in this PR. Probably almost all additional hooks would be gem hooks anyway.

In subsequent work, we can enable these config hooks to be added via YAML files that aren't part of `appmap-ruby` itself. For example, the `appmap-ruby` agent could be configured to look in an extension/configuration directory for additional builtin hooks. 

