### PR TITLE
fix: Missing gems will no longer attempt to be hooked

### DIFF
--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -226,7 +226,9 @@ module AppMap
         elsif ENV['DEBUG'] == 'true'
           warn msg
         end
-      end  
+
+        nil
+      end
 
       def ruby_minor_version
         @ruby_minor_version ||= RUBY_VERSION.split('.')[0..1].join('.').to_f

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -243,6 +243,21 @@ describe AppMap::Config, docker: false do
     FIXTURE
   end
 
+  describe AppMap::Config::Package do
+    describe :build_from_gem do
+      let(:mock_rails) { double(logger: double(info: true)) }
+
+      before do
+        stub_const('Rails', mock_rails)
+      end
+
+      it 'does not return a truthy value on failure' do
+        result = AppMap::Config::Package.build_from_gem('some_missing_gem_name', optional: true)
+        expect(result).to_not be_truthy
+      end
+    end
+  end
+
   context do
     let(:warnings) { @warnings ||= [] }
     let(:warning) { warnings.join }


### PR DESCRIPTION
Because we're propagating the return value of `Logger#info`, [a warning message](https://github.com/applandinc/appmap-ruby/blob/master/lib/appmap/config.rb#L69) causes [`Config::Package.build_from_gem`](https://github.com/applandinc/appmap-ruby/blob/master/lib/appmap/config.rb#L60) to return `true`, causing [`Config::TargetMethods.package_hooks`](https://github.com/applandinc/appmap-ruby/blob/master/lib/appmap/config.rb#L148) to continue processing hooks on an invalid type (`TrueClass` instead of `Config::Package`).

I'd considered making a type check here as well, but opted to leave it as is.
https://github.com/applandinc/appmap-ruby/blob/master/lib/appmap/config.rb#L157