### PR TITLE
feat: Report sub-packages in the class map

### DIFF
--- a/spec/class_map_spec.rb
+++ b/spec/class_map_spec.rb
@@ -16,7 +16,7 @@ describe 'AppMap::ClassMap' do
     end
 
     def ruby_method(method)
-      AppMap::Trace::RubyMethod.new AppMap::Config::Package.new, method.receiver.class.name, method, false
+      AppMap::Trace::RubyMethod.new AppMap::Config::Package.new('pkg'), method.receiver.class.name, method, false
     end
 
     def dig_map(map, depth)

--- a/spec/fixtures/hook/pkg_a/a.rb
+++ b/spec/fixtures/hook/pkg_a/a.rb
@@ -1,0 +1,7 @@
+module PkgA
+  class A
+    def self.hello
+      'hello'
+    end
+  end
+end

--- a/spec/fixtures/hook/sub_packages.rb
+++ b/spec/fixtures/hook/sub_packages.rb
@@ -1,0 +1,7 @@
+require_relative 'pkg_a/a'
+
+module SubPackages
+  def self.invoke_a
+    PkgA::A.hello
+  end
+end

--- a/spec/rails_recording_spec.rb
+++ b/spec/rails_recording_spec.rb
@@ -157,31 +157,31 @@ describe 'Rails' do
             )
 
             expect(appmap['classMap']).to include hash_including(
-              'name' => 'app/views',
+              'name' => 'app',
               'children' => include(hash_including(
-                'name' => 'app_views_users_index_html_haml',
+                'name' => 'views',
                 'children' => include(hash_including(
-                  'name' => 'render',
-                  'type' => 'function',
-                  'location' => 'app/views/users/index.html.haml',
-                  'static' => true,
-                  'labels' => [ 'mvc.template' ]
-                ))
-              ))
-            )
+                  'name' => 'app_views_users_index_html_haml',
+                  'children' => include(hash_including(
+                    'name' => 'render',
+                    'type' => 'function',
+                    'location' => 'app/views/users/index.html.haml',
+                    'static' => true,
+                    'labels' => [ 'mvc.template' ]
+                  )))))))
             expect(appmap['classMap']).to include hash_including(
-              'name' => 'app/views',
+              'name' => 'app',
               'children' => include(hash_including(
-                'name' => 'app_views_layouts_application_html_haml',
+                'name' => 'views',
                 'children' => include(hash_including(
-                  'name' => 'render',
-                  'type' => 'function',
-                  'location' => 'app/views/layouts/application.html.haml',
-                  'static' => true,
-                  'labels' => [ 'mvc.template' ]
-                ))
-              ))
-            )
+                  'name' => 'app_views_layouts_application_html_haml',
+                  'children' => include(hash_including(
+                    'name' => 'render',
+                    'type' => 'function',
+                    'location' => 'app/views/layouts/application.html.haml',
+                    'static' => true,
+                    'labels' => [ 'mvc.template' ]
+                  )))))))
           end
         end
 


### PR DESCRIPTION
When a recorded path has recorded sub-folders, appmap-ruby will produce a class map with nested `package` elements.
