### PR TITLE
ci: Test ruby 3.1

### DIFF
--- a/ext/appmap/extconf.rb
+++ b/ext/appmap/extconf.rb
@@ -1,7 +1,7 @@
 require "mkmf"
 
 
-$CFLAGS='-Werror'
+$CFLAGS='-Werror ' + $CFLAGS
 
 # Per https://bugs.ruby-lang.org/issues/17865,
 # compound-token-split-by-macro was added in clang 12 and broke

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 module AppMap
+  NEW_RUBY = Util.ruby_minor_version >= 2.7
+  if NEW_RUBY && !Proc.instance_methods.include?(:ruby2_keywords)
+    warn "Ruby is #{RUBY_VERSION}, but Procs don't respond to #ruby2_keywords"
+  end
+
   class Hook
     class Method
       attr_reader :hook_package, :hook_class, :hook_method
@@ -56,7 +61,7 @@ module AppMap
 
           call_instance_method = -> {
             # https://github.com/applandinc/appmap-ruby/issues/153
-            if Util.ruby_minor_version >= 2.7 && is_array_containing_empty_hash.(args) && hook_method.arity == 1
+            if NEW_RUBY && is_array_containing_empty_hash.(args) && hook_method.arity == 1
               instance_method.call({}, &block)
             else
               instance_method.call(*args, &block)


### PR DESCRIPTION
This changes target a problem we've seen calling a method that takes a Hash followed by a keyword argument. One way this could happen is if an instance of `Proc` doesn't respond to `#ruby2_keywords`, so log a warning if this is is the case.