### PR TITLE
fix: Ensure Content-Type is included in request headers

### DIFF
--- a/spec/rails_recording_spec.rb
+++ b/spec/rails_recording_spec.rb
@@ -33,7 +33,8 @@ describe 'Rails' do
                 'http_server_request' => hash_including(
                   'request_method' => 'POST',
                   'normalized_path_info' => '/api/users',
-                  'path_info' => '/api/users'
+                  'path_info' => '/api/users',
+                  'headers' => hash_including('Content-Type' => 'application/x-www-form-urlencoded'),
                 ),
                 'message' => include(
                   hash_including(


### PR DESCRIPTION
Rack doesn’t prepend HTTP_ to the content type header, so we are usually/always missing it on requests.
