### PR TITLE
fix: No longer bundle @appland/appmap with this gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ jobs:
     env:
       # GEM_ALTERNATIVE_NAME only needed for deployment 
       - GEM_ALTERNATIVE_NAME=''
-    script: bundle exec rake
 
 before_deploy:
   - |
@@ -51,4 +50,4 @@ deploy:
     script: ./release.sh
     on:
       branch: master
-      condition: "$TRAVIS_RUBY_VERSION = 2.7"
+      condition: "$TRAVIS_RUBY_VERSION = 3.0"

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -23,12 +23,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  strip_dir = ->(file) { file.index(Dir.pwd) == 0 ? file[Dir.pwd.length+1...file.length] : file }
-  Dir.glob(File.join(__dir__, 'node_modules/**/*')).map(&strip_dir).each do |filename|
-    next if File.directory?(filename) || filename.length > 100
-    spec.files << filename
-  end
-
   spec.extensions << "ext/appmap/extconf.rb"
   spec.require_paths = ['lib']
 

--- a/lib/appmap/command/index.rb
+++ b/lib/appmap/command/index.rb
@@ -16,7 +16,7 @@ module AppMap
 
         arguments.unshift 'index'
         arguments.unshift APPMAP_JS
-        arguments.unshift 'node'
+        arguments.unshift 'npx'
 
         exec(*arguments)
       end

--- a/lib/appmap/command/inspect.rb
+++ b/lib/appmap/command/inspect.rb
@@ -16,7 +16,7 @@ module AppMap
 
         arguments.unshift 'inspect'
         arguments.unshift APPMAP_JS
-        arguments.unshift 'node'
+        arguments.unshift 'npx'
 
         exec(*arguments)
       end

--- a/lib/appmap/node_cli.rb
+++ b/lib/appmap/node_cli.rb
@@ -6,7 +6,7 @@ require 'appmap/command_error'
 module AppMap
   # Utilities for invoking the +@appland/appmap+ CLI.
   class NodeCLI
-    APPMAP_JS = Pathname.new(__dir__).join('../../node_modules/@appland/appmap/src/cli.js').expand_path.to_s
+    APPMAP_JS = '@appland/appmap'
 
     attr_reader :verbose
     # Directory to scan for AppMaps.
@@ -32,7 +32,7 @@ module AppMap
     def command(command, options = {})
       command.unshift << '--verbose' if verbose
       command.unshift APPMAP_JS
-      command.unshift 'node'
+      command.unshift 'npx'
 
       warn command.join(' ') if verbose
       stdout, stderr, status = Open3.capture3({ 'NODE_OPTIONS' => '--trace-warnings' }, *command.map(&:shellescape), options)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/applandinc/appmap-ruby#readme",
   "dependencies": {
-    "@appland/appmap": "^3.0.0"
+    "@appland/appmap": "^3.18.3"
   }
 }

--- a/release.sh
+++ b/release.sh
@@ -13,5 +13,4 @@ else
 fi
 
 set -ex
-yarn install --prod
 exec semantic-release $RELEASE_FLAGS

--- a/spec/fixtures/rails6_users_app/Dockerfile
+++ b/spec/fixtures/rails6_users_app/Dockerfile
@@ -13,12 +13,19 @@ RUN curl -fsSL https://fnm.vercel.app/install | bash \
     && source /root/.bashrc \
     && fnm install --lts \
     && echo 'fnm default $(fnm current)' >> ~/.bashrc \
-    && ln -s $(which node) /usr/local/bin/node
+    && ln -s $(which node) /usr/local/bin/ \
+    && ln -s $(which npx) /usr/local/bin/ \
+    && npm install -g yarn \
+    && ln -s $(which yarn) /usr/local/bin/
 
 RUN mkdir /app
 WORKDIR /app
 
 RUN gem install -N bundler
+
+COPY package.json .
+
+RUN yarn install
 
 COPY Gemfile .
 

--- a/spec/fixtures/rails6_users_app/package.json
+++ b/spec/fixtures/rails6_users_app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "rails6_users_app",
+  "version": "1.0.0",
+  "license": "MIT",
+  "devDependencies": {
+    "@appland/appmap": "^3.18.3"
+  }
+}

--- a/spec/fixtures/rails6_users_app/yarn.lock
+++ b/spec/fixtures/rails6_users_app/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@appland/appmap@^3.18.1":
-  version "3.18.1"
-  resolved "https://registry.yarnpkg.com/@appland/appmap/-/appmap-3.18.1.tgz#031b63b4920677695437ab3ba24f2d81d9ba3595"
-  integrity sha512-9jCCD5H/Fv31IIDVAEETb/TRjFJYobS27dWIQ4eh1nG1HT+Nfbe6tx3hz63COn6qYojY5Y8QvavlghIik8REnQ==
+"@appland/appmap@^3.18.2":
+  version "3.18.2"
+  resolved "https://registry.yarnpkg.com/@appland/appmap/-/appmap-3.18.2.tgz#5de0d90b8853f2d2e2a6ef2af166250ec2d8e85c"
+  integrity sha512-5GOvu4FkVrMGg0JNC8C01YG3s5CdkkeZ0OutTpuvO4w5FP7YFM/xP08vMuv5/9xdSLX2mB1PiPyRwp5E0lqqWQ==
   dependencies:
     "@appland/components" "1.23.0"
     "@appland/diagrams" "1.5.1"
@@ -68,6 +68,14 @@
     deepmerge "^4.2.2"
     sql-formatter "^4.0.2"
 
+"@appland/models@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@appland/models/-/models-1.14.1.tgz#71e26590c18c38643f1fbd88bd4396577a05a25e"
+  integrity sha512-pS3MGN8u5j7vc8UmcSU+oYK0ydcxXH2mRFiHco7PpGNaSCNT1XZtK4ldtc+9anM1wHRd8G3S++Hm8Y5s2DFuuA==
+  dependencies:
+    "@appland/sql-parser" "^1.4.0"
+    crypto-js "^4.0.0"
+
 "@appland/models@^1.8.1", "@appland/models@^1.9.0":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@appland/models/-/models-1.12.1.tgz#45cc189e2a7deb5dc98b3bb51da54cf789c32414"
@@ -80,6 +88,11 @@
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@appland/sql-parser/-/sql-parser-1.3.0.tgz#2664079f5c042aa48d4e4c28fb0dfee5414c8f5a"
   integrity sha512-J0g/3DAsyMkPdNYAnzw8WUApNWFkZMKHAywiV8iRrWNUnowV/ZJR1/GJW2ys7EZr1F23Go1mYDU4S5VeRfdiRg==
+
+"@appland/sql-parser@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@appland/sql-parser/-/sql-parser-1.4.0.tgz#ffd655ed14b66ad5712dce5a98a0ffa2d4071952"
+  integrity sha512-9YMv8lGjf4gcZVwGC2Eq3+M8YZk7SUEba6hAjAUzy9ZEYweKXjG6pbWAEB/oOYXZE6Sy3c89pkR4se+OiRAgTA==
 
 "@azure/abort-controller@^1.0.0":
   version "1.0.4"
@@ -265,9 +278,9 @@ acorn@^7.1.1:
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.2.4:
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
-  integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 agent-base@6:
   version "6.0.2"
@@ -306,11 +319,6 @@ ansi-escapes@^4.2.1:
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
   dependencies:
     type-fest "^0.21.3"
-
-ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -375,9 +383,9 @@ async-listener@^0.6.0:
     shimmer "^1.1.0"
 
 async@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -488,9 +496,9 @@ chardet@^0.7.0:
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 chokidar@^3.5.1:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
-  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -515,11 +523,10 @@ cli-cursor@^3.1.0:
     restore-cursor "^3.1.0"
 
 cli-progress@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.9.0.tgz#25db83447deb812e62d05bac1af9aec5387ef3d4"
-  integrity sha512-g7rLWfhAo/7pF+a/STFH/xPyosaL1zgADhI0OM83hl3c7S43iGvJWEAV2QuDOnQ8i6EMBj/u4+NTd0d5L+4JfA==
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.10.0.tgz#63fd9d6343c598c93542fdfa3563a8b59887d78a"
+  integrity sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==
   dependencies:
-    colors "^1.1.2"
     string-width "^4.2.0"
 
 cli-spinners@^2.5.0:
@@ -584,11 +591,6 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colors@^1.1.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -623,9 +625,9 @@ connected-domain@^1.0.0:
   integrity sha1-v+dyOMdL5FOnnwy2BY3utPI1jpM=
 
 console-table-printer@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/console-table-printer/-/console-table-printer-2.9.0.tgz#5d75374bc94ae57048587604829cb914b282a088"
-  integrity sha512-20o73riqnclLYJt5ggNqP2ZjtgL5OxJPWzTVi3LyVFVtubMH0XN+oOn9outL1XI5ldJgPcjdMAWc92vRscHAKA==
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/console-table-printer/-/console-table-printer-2.10.0.tgz#4a6875b95071b36542d1c55c6d9dcc6206e1e9f0"
+  integrity sha512-7pTsysaJs1+R+OO4cCtJbl+Lr4piHYIhi7/V1qHbOg/uiYgq2yUINFgvXZtVHqm9qpW0+Uk190qkGcKvzdunvg==
   dependencies:
     simple-wcswidth "^1.0.1"
 
@@ -638,9 +640,9 @@ continuation-local-storage@^3.2.1:
     emitter-listener "^1.1.1"
 
 crypto-js@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
-  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -863,9 +865,9 @@ debounce-fn@^4.0.0:
     mimic-fn "^3.0.0"
 
 debug@4:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
 
@@ -875,9 +877,9 @@ decimal.js@^10.2.1:
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
 
 deep-is@~0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 deepmerge@^4.2.2:
   version "4.2.2"
@@ -982,9 +984,9 @@ esprima@^4.0.1:
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 estraverse@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
-  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -1082,9 +1084,9 @@ glob-parent@~5.1.2:
     is-glob "^4.0.1"
 
 glob@^7.1.6:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1094,9 +1096,9 @@ glob@^7.1.6:
     path-is-absolute "^1.0.0"
 
 graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
-  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
 grapheme-splitter@^1.0.4:
   version "1.0.4"
@@ -1222,9 +1224,9 @@ is-fullwidth-code-point@^3.0.0:
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-glob@^4.0.1, is-glob@~4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
-  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -1383,17 +1385,17 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-mime-db@1.49.0:
-  version "1.49.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
-  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
+mime-db@1.51.0:
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
+  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
 mime-types@^2.1.12:
-  version "2.1.32"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.32.tgz#1d00e89e7de7fe02008db61001d9e02852670fd5"
-  integrity sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
+  version "2.1.34"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
+  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
   dependencies:
-    mime-db "1.49.0"
+    mime-db "1.51.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -1406,9 +1408,9 @@ mimic-fn@^3.0.0:
   integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
 minimatch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
+  integrity sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -1539,9 +1541,9 @@ path-is-absolute@^1.0.0:
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 picomatch@^2.0.4, picomatch@^2.2.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
-  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pkg-up@^3.1.0:
   version "3.1.0"
@@ -1704,7 +1706,7 @@ stack-chain@^1.3.7:
   resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
   integrity sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
 
-string-width@^4.0.0, string-width@^4.2.2, string-width@^4.2.3:
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1713,15 +1715,6 @@ string-width@^4.0.0, string-width@^4.2.2, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
-  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.0"
-
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -1729,14 +1722,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
-  dependencies:
-    ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -1978,9 +1964,9 @@ wrappy@1:
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 ws@^7.4.6:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
-  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
+  integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"

--- a/spec/swagger/swagger_spec.rb
+++ b/spec/swagger/swagger_spec.rb
@@ -27,21 +27,74 @@ describe 'rake appmap:swagger' do
 
   # The swagger-building logic is mostly in the JS code. So what we are really testing here
   # is the Rails integration - the rake task and integration with the appmap.yml.
-  # And of course the bundling of the JS code by the appmap gem.
   it 'generates openapi_stable.yml' do
     swagger = YAML.load(File.read(File.join(tmpdir, 'swagger', 'openapi_stable.yaml'))).deep_symbolize_keys
 
-    expect(swagger).to match(
-      hash_including(
-        openapi: /^\d\.\d\.\d$/,
-        info: {
-          title: 'Usersapp API',
-          version: '1.1.0'
-        },
-        paths: hash_including(
-          :'/api/users' => an_instance_of(Hash)
-        )
-      )
-    )
+    expect(swagger).to eq(YAML.load(<<~YAML
+      :openapi: 3.0.1
+      :info:
+        :title: My project
+        :version: v1
+      :paths:
+        :/api/users:
+          :get:
+            :responses:
+              :200:
+                :content:
+                  :application/json: {}
+            :requestBody:
+              :content: {}
+          :post:
+            :responses:
+              :201:
+                :content:
+                  :application/json: {}
+              :422:
+                :content:
+                  :application/json: {}
+            :requestBody:
+              :content:
+                :application/x-www-form-urlencoded:
+                  :schema:
+                    :type: object
+                    :properties:
+                      :login:
+                        :type: string
+                      :password:
+                        :type: string
+                      :user:
+                        :type: object
+                        :properties:
+                          :login:
+                            :type: string
+                          :password:
+                            :type: string
+        :/users:
+          :get:
+            :responses:
+              :200:
+                :content:
+                  :text/html: {}
+        :/users/{id}:
+          :get:
+            :responses:
+              :200:
+                :content:
+                  :text/plain: {}
+            :parameters:
+            - :name: id
+              :in: path
+              :schema:
+                :type: string
+              :required: true
+      :components:
+        :securitySchemes: {}
+      :servers:
+      - :url: http://{defaultHost}
+        :variables:
+          :defaultHost:
+            :default: localhost:3000
+      YAML
+    ))
   end
 end


### PR DESCRIPTION
You might be familiar with how the appmap-ruby `swagger` Rake tasks used a bundled copy of appmap-js. Now that we are requiring the installation of other code from NPM, such as `@appland/scanner`, it doesn’t make sense to do this any more. It was fragile and it kept breaking. This update runs the `@appland/appmap openapi` using `npx`

The user must install `@appland/appmap` to the enclosing project.

This also applies to the `depends` task.

## TODO

* Update https://appland.com/docs/reference/appmap-ruby.html#swagger-openapi-generation

