### PR TITLE
fix: Override method accessors to provide the correct signature

### DIFF
--- a/spec/fixtures/hook/report_parameters.rb
+++ b/spec/fixtures/hook/report_parameters.rb
@@ -1,0 +1,8 @@
+
+class ReportParameters
+  def to_s; self.class.name; end
+
+  def report_parameters(*args, kw1:, kw2: 'kw2', **kws)
+    method(:report_parameters).parameters
+  end
+end


### PR DESCRIPTION
Patch Object and Module to provide the proper parameters (method signature) on hooked methods. 