### PR TITLE
feat: Hook kernel eval

### DIFF
--- a/lib/appmap/builtin_hooks/marshal.yml
+++ b/lib/appmap/builtin_hooks/marshal.yml
@@ -1,8 +1,0 @@
-- methods:
-  - Marshal#load
-  - Marshal#restore
-  require_name: ruby
-  label: deserialize.unsafe
-- method: Marshal#dump
-  require_name: ruby
-  label: serialize

--- a/lib/appmap/builtin_hooks/open3.yml
+++ b/lib/appmap/builtin_hooks/open3.yml
@@ -1,0 +1,13 @@
+- methods:
+  - Open3#capture2
+  - Open3#capture2e
+  - Open3#capture3
+  - Open3#pipeline
+  - Open3#pipeline_r
+  - Open3#pipeline_rw
+  - Open3#pipeline_start
+  - Open3#pipeline_w
+  - Open3#popen2
+  - Open3#popen2e
+  - Open3#popen3
+  label: system.exec

--- a/lib/appmap/builtin_hooks/ruby.yml
+++ b/lib/appmap/builtin_hooks/ruby.yml
@@ -1,0 +1,39 @@
+- methods:
+  - Marshal#load
+  - Marshal#restore
+  require_name: ruby
+  label: deserialize.unsafe
+- method: Marshal#dump
+  require_name: ruby
+  label: serialize
+- method: String#pack
+  require_name: ruby
+  label: string.pack
+- methods:
+  - String#unpack
+  - String#unpack1
+  require_name: ruby
+  label: string.unpack
+- methods:
+  # TODO: eval does not happen in the right context, and therefore any new constants
+  # which are defined are placed on the wrong module/class.
+#  - Kernel#eval
+  - Binding#eval
+  - BasicObject#instance_eval
+# These methods cannot be hooked as far as I can tell.
+# Why? When calling one of these functions, the context at the point of 
+# definition is used. It's not possible to bind class_eval to a new context.
+#  - Module#class_eval
+#  - Module#module_eval
+  require_name: ruby
+  label: lang.eval
+- methods:
+  - IO#popen
+  - Kernel#exec
+  - Kernel#spawn
+  - Kernel#syscall
+  - Kernel#system
+  - Process#exec
+  - Process#spawn
+  require_name: ruby
+  label: system.exec

--- a/lib/appmap/builtin_hooks/ruby.yml
+++ b/lib/appmap/builtin_hooks/ruby.yml
@@ -15,9 +15,7 @@
   require_name: ruby
   label: string.unpack
 - methods:
-  # TODO: eval does not happen in the right context, and therefore any new constants
-  # which are defined are placed on the wrong module/class.
-#  - Kernel#eval
+  - Kernel#eval
   - Binding#eval
   - BasicObject#instance_eval
 # These methods cannot be hooked as far as I can tell.

--- a/lib/appmap/cucumber.rb
+++ b/lib/appmap/cucumber.rb
@@ -51,7 +51,7 @@ module AppMap
         appmap['metadata'] = update_metadata(scenario, appmap['metadata'])
         scenario_filename = AppMap::Util.scenario_filename(appmap['metadata']['name'])
 
-        AppMap::Util.write_appmap(File.join(APPMAP_OUTPUT_DIR, scenario_filename), JSON.generate(appmap))
+        AppMap::Util.write_appmap(File.join(APPMAP_OUTPUT_DIR, scenario_filename), appmap)
       end
 
       def enabled?

--- a/lib/appmap/gem_hooks/actionview.yml
+++ b/lib/appmap/gem_hooks/actionview.yml
@@ -11,3 +11,7 @@
   label: mvc.template.resolver
   handler_class: AppMap::Handler::Rails::Template::ResolverHandler
   require_name: action_view
+- methods:
+  - ActionView::Helpers::SanitizeHelper#sanitize
+  label: string.html_safe
+  require_name: action_view

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -116,6 +116,11 @@ module AppMap
               end
 
               methods = []
+              # irb(main):001:0> Kernel.public_instance_method(:system)
+              # (irb):1:in `public_instance_method': method `system' for module `Kernel' is  private (NameError)
+              if base_cls == Kernel
+                methods << [ base_cls, base_cls.instance_method(method_name) ] rescue nil
+              end
               methods << [ base_cls, base_cls.public_instance_method(method_name) ] rescue nil
               methods << [ base_cls, base_cls.protected_instance_method(method_name) ] rescue nil
               if base_cls.respond_to?(:singleton_class)

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -105,6 +105,9 @@ module AppMap
 
             Array(hook.method_names).each do |method_name|
               method_name = method_name.to_sym
+
+              warn "AppMap: Initiating hook for builtin #{class_name} #{method_name}" if LOG
+
               base_cls = Util.class_from_string(class_name, must: false)
               next unless base_cls
 

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -125,8 +125,12 @@ module AppMap
         hook_method_parameters = hook_method.parameters.dup.freeze
         SIGNATURES[[ hook_class, hook_method.name ]] = hook_method_parameters
 
-        hook_class.ancestors.first.tap do |cls|
-          cls.define_method_with_arity(hook_method.name, hook_method.arity, hook_method_def)
+        hook_class.ancestors.find { |cls| cls.method_defined?(hook_method.name, false) }.tap do |cls|
+          if cls
+            cls.define_method_with_arity(hook_method.name, hook_method.arity, hook_method_def)
+          else
+            warn "#{hook_method.name} not found on #{hook_class}"
+          end
         end
       end
 

--- a/lib/appmap/minitest.rb
+++ b/lib/appmap/minitest.rb
@@ -120,7 +120,7 @@ module AppMap
         }.compact
         fname = AppMap::Util.scenario_filename(name)
 
-        AppMap::Util.write_appmap(File.join(APPMAP_OUTPUT_DIR, fname), JSON.generate(appmap))
+        AppMap::Util.write_appmap(File.join(APPMAP_OUTPUT_DIR, fname), appmap)
       end
 
       def enabled?

--- a/lib/appmap/record.rb
+++ b/lib/appmap/record.rb
@@ -23,5 +23,5 @@ at_exit do
     'classMap' => AppMap.class_map(tracer.event_methods),
     'events' => events
   }
-  AppMap::Util.write_appmap('appmap.json', JSON.generate(appmap))
+  AppMap::Util.write_appmap('appmap.json', appmap)
 end

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -205,7 +205,7 @@ module AppMap
         }.compact
         fname = AppMap::Util.scenario_filename(name)
 
-        AppMap::Util.write_appmap(File.join(APPMAP_OUTPUT_DIR, fname), JSON.generate(appmap))
+        AppMap::Util.write_appmap(File.join(APPMAP_OUTPUT_DIR, fname), appmap)
       end
 
       def enabled?

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -171,7 +171,7 @@ module AppMap
         mode = File::RDWR | File::CREAT | File::EXCL
         ::Dir::Tmpname.create([ 'appmap_', '.json' ]) do |tmpname|
           tempfile = File.open(tmpname, mode)
-          tempfile.write(appmap)
+          tempfile.write(JSON.generate(appmap))
           tempfile.close
           # Atomically move the tempfile into place.
           FileUtils.mv tempfile.path, filename

--- a/spec/display_string_spec.rb
+++ b/spec/display_string_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'appmap/event'
+
+include AppMap
+
+describe 'display_string' do
+  def display_string(value)
+    Event::MethodEvent.display_string value
+  end
+
+  def compare_display_string(value, expected)
+    expect(display_string(value)).to eq(expected)
+  end
+
+  context 'for a' do
+    it 'String' do
+      compare_display_string 'foo', 'foo'
+    end
+    it 'long String' do
+      compare_display_string 'foo' * 100, 'foo' * 33 + 'f (...200 more characters)'
+    end
+    it 'Array' do
+      compare_display_string([ 1, 'my', :bar, [ 2, 3 ], { 4 => 5 } ], '[1, my, :bar, [2, 3], {4=>5}]')
+    end
+    it 'large Array' do
+      compare_display_string 50.times.map { |i| i }, '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9 (...40 more items)]'
+    end
+    it 'large Hash' do
+      compare_display_string(50.times.map { |i| [ i*2, i*2+1] }.to_h, '{0=>1, 2=>3, 4=>5, 6=>7, 8=>9, 10=>11, 12=>13, 14=>15, 16=>17, 18=>19 (...40 more entries)}')
+    end
+    it 'Hash' do
+      compare_display_string({ 1 => 2, 'my' => 'neighbor', bar: :baz, ary: [ 1, 2 ]}, '{1=>2, my=>neighbor, :bar=>:baz, :ary=>[1, 2]}')
+    end
+    it 'big Hash' do
+      compare_display_string(50.times.map { |i| [ i*2, i*2+1] }.to_h, '{0=>1, 2=>3, 4=>5, 6=>7, 8=>9, 10=>11, 12=>13, 14=>15, 16=>17, 18=>19 (...40 more entries)}')
+    end
+  end
+end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -1136,7 +1136,7 @@ describe 'AppMap class Hooking', docker: false do
       :parameters:
       - :name: :args
         :class: Array
-        :value: '["foo"]'
+        :value: "[foo]"
         :kind: :rest
       - :name: :kw1
         :class: String

--- a/spec/rails_recording_spec.rb
+++ b/spec/rails_recording_spec.rb
@@ -78,7 +78,7 @@ describe 'Rails' do
                 'name' => 'params',
                 'class' => 'ActiveSupport::HashWithIndifferentAccess',
                 'object_id' => Integer,
-                'value' => '{"login"=>"alice"}',
+                'value' => '{login=>alice}',
                 'kind' => 'req'
               ),
               'receiver' => anything

--- a/spec/record_net_http_spec.rb
+++ b/spec/record_net_http_spec.rb
@@ -127,7 +127,7 @@ describe 'Net::HTTP handler' do
         :message:
         - :name: ary
           :class: Array
-          :value: '["1", "2"]'
+          :value: "[1, 2]"
         EVENT
       end
 

--- a/test/gem_test.rb
+++ b/test/gem_test.rb
@@ -24,7 +24,7 @@ class GemTest < Minitest::Test
       appmap_file = 'tmp/appmap/minitest/Parser_parser.appmap.json'
       appmap = JSON.parse(File.read(appmap_file))
       events = appmap['events']
-      assert_equal 2, events.size
+      assert_equal 6, events.size
       assert_equal 'call', events.first['event']
       assert_equal 'default_parser', events.first['method_id']
       assert_match /\lib\/parser\/base\.rb$/, events.first['path']


### PR DESCRIPTION
The hook of `Kernel.eval` does not happen in the right module/class context. Therefore if you try and eval a string like this:

```
module MyModule
  eval "class Foo; end"
end
```

The constant `Foo` is defined on `AppMap::Hook::Method` rather than on `MyModule`. We would like to hook `eval` so that any new constants are defined on the right module. 

PS Is there any other way to dynamically evaluate a language string in Ruby? If so, we would need to fix this there as well. I think so : `class_eval` and `class_exec` - https://ruby-doc.org/core-2.6/Module.html#method-i-class_eval

This could also be the root cause of the note that I left in `ruby.yml`:

```
# These methods cannot be hooked as far as I can tell.
# Why? When calling one of these functions, the context at the point of 
# definition is used. It's not possible to bind class_eval to a new context.
#  - Module#class_eval
#  - Module#module_eval
```


