### PR TITLE
Autoload hook handlers

### DIFF
--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -206,8 +206,8 @@ module AppMap
         }.compact
 
         handler_class = hook_decl['handler_class']
-        options[:handler_class] = Util.class_from_string(handler_class) if handler_class
-        
+        options[:handler_class] = Object.const_get(handler_class) if handler_class
+
         package_hooks(methods, **options)
       end
 

--- a/lib/appmap/config.rb
+++ b/lib/appmap/config.rb
@@ -4,8 +4,7 @@ require 'pathname'
 require 'set'
 require 'yaml'
 require 'appmap/util'
-require 'appmap/handler/net_http'
-require 'appmap/handler/rails/template'
+require 'appmap/handler'
 require 'appmap/service/guesser'
 require 'appmap/swagger/configuration'
 require 'appmap/depends/configuration'
@@ -206,7 +205,7 @@ module AppMap
         }.compact
 
         handler_class = hook_decl['handler_class']
-        options[:handler_class] = Object.const_get(handler_class) if handler_class
+        options[:handler_class] = Handler.find(handler_class) if handler_class
 
         package_hooks(methods, **options)
       end

--- a/lib/appmap/handler.rb
+++ b/lib/appmap/handler.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'active_support/inflector/methods'
+
+module AppMap
+  # Specific hook handler classes and general related utilities.
+  module Handler
+    # Try to find handler module with a given name.
+    #
+    # If the module is not loaded, tries to require the appropriate file
+    # using the usual conventions, eg. `Acme::Handler::AppMap` will try
+    # to require `acme/handler/app_map`, then `acme/handler` and
+    # finally `acme`. Raises NameError if the module could not be loaded
+    # this way.
+    def self.find(name)
+      begin
+        return Object.const_get name
+      rescue NameError
+        try_load ActiveSupport::Inflector.underscore name
+      end
+      Object.const_get name
+    end
+
+    def self.try_load(fname)
+      fname = fname.sub %r{^app_map/}, 'appmap/'
+      fname = fname.split '/'
+      until fname.empty?
+        begin
+          require fname.join '/'
+          return
+        rescue LoadError
+          # pass
+        end
+        fname.pop
+      end
+    end
+  end
+end

--- a/lib/appmap/hook.rb
+++ b/lib/appmap/hook.rb
@@ -108,8 +108,11 @@ module AppMap
 
               warn "AppMap: Initiating hook for builtin #{class_name} #{method_name}" if LOG
 
-              base_cls = Util.class_from_string(class_name, must: false)
-              next unless base_cls
+              begin
+                base_cls = Object.const_get class_name
+              rescue NameError
+                next
+              end
 
               hook_method = lambda do |entry|
                 cls, method = entry

--- a/lib/appmap/util.rb
+++ b/lib/appmap/util.rb
@@ -21,14 +21,6 @@ module AppMap
     WHITE   = "\e[37m"
 
     class << self
-      def class_from_string(fq_class, must: true)
-        fq_class.split('::').inject(Object) do |mod, class_name|
-          mod.const_get(class_name)
-        end
-      rescue NameError
-        raise if must
-      end
-
       def parse_function_name(name)
         package_tokens = name.split('/')
 


### PR DESCRIPTION
This makes it easier for the user to specify custom handlers.

For example, specifying
    
        - methods:
          - Acme::Request.make
          handler_class: Acme::Request::AppmapHandler
    
in the config file will make AppMap automatically require `acme/request/appmap_handler` before setting up the hook.