### PR TITLE
feat: Parameter schema, query EXPLAIN and size

### DIFF
--- a/lib/appmap/agent.rb
+++ b/lib/appmap/agent.rb
@@ -104,5 +104,9 @@ module AppMap
     def parameter_schema?
       ENV['APPMAP_PARAMETER_SCHEMA'] == 'true'
     end
+
+    def explain_queries?
+      ENV['APPMAP_EXPLAIN_QUERIES'] == 'true'
+    end
   end
 end

--- a/lib/appmap/agent.rb
+++ b/lib/appmap/agent.rb
@@ -100,5 +100,9 @@ module AppMap
       @metadata ||= Metadata.detect.freeze
       Util.deep_dup(@metadata)
     end
+
+    def parameter_schema?
+      ENV['APPMAP_PARAMETER_SCHEMA'] == 'true'
+    end
   end
 end

--- a/lib/appmap/event.rb
+++ b/lib/appmap/event.rb
@@ -243,6 +243,7 @@ module AppMap
                 value: display_string(value),
                 kind: param_type
                 }.tap do |param|
+                  param[:size] = value.size if value.respond_to?(:size) && value.is_a?(Enumerable)
                   add_schema param, value
                 end
             end
@@ -308,6 +309,7 @@ module AppMap
                 value: display_string(return_value),
                 object_id: return_value.__id__
               }.tap do |param|
+                param[:size] = return_value.size if return_value.respond_to?(:size) && return_value.is_a?(Enumerable)
                 add_schema param, return_value, always: parameter_schema
               end
             end

--- a/lib/appmap/gem_hooks/actionpack.yml
+++ b/lib/appmap/gem_hooks/actionpack.yml
@@ -43,3 +43,9 @@
   - ActionController::Instrumentation#redirect_to
   label: mvc.controller
   require_name: action_controller
+- methods:
+  - AbstractController::Rendering#render_to_body
+  - ActionController::Renderers#render_to_body
+  label: mvc.render
+  handler_class: AppMap::Handler::Rails::RenderHandler
+  require_name: action_controller

--- a/lib/appmap/handler.rb
+++ b/lib/appmap/handler.rb
@@ -5,6 +5,7 @@ require 'active_support/inflector/methods'
 module AppMap
   # Specific hook handler classes and general related utilities.
   module Handler
+    TEMPLATE_RENDER_FORMAT = 'appmap.handler.template.return_value_format'
     TEMPLATE_RENDER_VALUE = 'appmap.handler.template.return_value'
 
     # Try to find handler module with a given name.

--- a/lib/appmap/handler.rb
+++ b/lib/appmap/handler.rb
@@ -5,6 +5,8 @@ require 'active_support/inflector/methods'
 module AppMap
   # Specific hook handler classes and general related utilities.
   module Handler
+    TEMPLATE_RENDER_VALUE = 'appmap.handler.template.return_value'
+
     # Try to find handler module with a given name.
     #
     # If the module is not loaded, tries to require the appropriate file

--- a/lib/appmap/handler/rails/render_handler.rb
+++ b/lib/appmap/handler/rails/render_handler.rb
@@ -6,9 +6,20 @@ module AppMap
       class RenderHandler < AppMap::Handler::Function
         def handle_call(receiver, args)
           options, _ = args
+          # TODO: :file, :xml
+          # https://guides.rubyonrails.org/v5.1/layouts_and_rendering.html
           if options[:json]
-            Thread.current[TEMPLATE_RENDER_VALUE] = options[:json]
+            Thread.current[TEMPLATE_RENDER_FORMAT] = :json
           end
+
+          super
+        end
+
+        def handle_return(call_event_id, elapsed, return_value, exception)
+          if Thread.current[TEMPLATE_RENDER_FORMAT] == :json
+            Thread.current[TEMPLATE_RENDER_VALUE] = JSON.parse(return_value) rescue nil
+          end
+          Thread.current[TEMPLATE_RENDER_FORMAT] = nil
 
           super
         end

--- a/lib/appmap/handler/rails/render_handler.rb
+++ b/lib/appmap/handler/rails/render_handler.rb
@@ -1,0 +1,18 @@
+require 'appmap/handler/function'
+
+module AppMap
+  module Handler
+    module Rails
+      class RenderHandler < AppMap::Handler::Function
+        def handle_call(receiver, args)
+          options, _ = args
+          if options[:json]
+            Thread.current[TEMPLATE_RENDER_VALUE] = options[:json]
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/appmap/handler/rails/request_handler.rb
+++ b/lib/appmap/handler/rails/request_handler.rb
@@ -7,6 +7,9 @@ require 'appmap/util'
 module AppMap
   module Handler
     module Rails
+
+      TEMPLATE_RENDER_VALUE = 'appmap.handler.rails.template.return_value'
+
       module RequestHandler
         class HTTPServerRequest < AppMap::Event::MethodEvent
           attr_accessor :normalized_path_info, :request_method, :path_info, :params, :headers
@@ -46,8 +49,7 @@ module AppMap
                     value: self.class.display_string(val),
                     object_id: val.__id__,
                   }.tap do |message|
-                    properties = object_properties(val)
-                    message[:properties] = properties if properties
+                    AppMap::Event::MethodEvent.add_schema message, val, always: true
                   end
                 end
               end
@@ -67,16 +69,16 @@ module AppMap
           end
         end
 
-        class HTTPServerResponse < AppMap::Event::MethodReturnIgnoreValue
+        class HTTPServerResponse < AppMap::Event::MethodReturn
           attr_accessor :status, :headers
 
-          def initialize(response, parent_id, elapsed)
-            super AppMap::Event.next_id_counter, :return, Thread.current.object_id
-
-            self.status = response.status
-            self.parent_id = parent_id
-            self.elapsed = elapsed
-            self.headers = response.headers.dup
+          class << self
+            def build_from_invocation(parent_id, return_value, elapsed, response, event: HTTPServerResponse.new)
+              event ||= HTTPServerResponse.new
+              event.status = response.status
+              event.headers = response.headers.dup
+              AppMap::Event::MethodReturn.build_from_invocation parent_id, return_value, nil, elapsed: elapsed, event: event
+            end
           end
 
           def to_h
@@ -108,7 +110,9 @@ module AppMap
           end
 
           def after_hook(receiver, call_event, elapsed, *)
-            return_event = HTTPServerResponse.new receiver.response, call_event.id, elapsed
+            return_value = Thread.current[TEMPLATE_RENDER_VALUE]
+            Thread.current[TEMPLATE_RENDER_VALUE] = nil
+            return_event = HTTPServerResponse.build_from_invocation call_event.id, return_value, elapsed, receiver.response
             AppMap.tracing.record_event return_event
           end
         end

--- a/lib/appmap/handler/rails/request_handler.rb
+++ b/lib/appmap/handler/rails/request_handler.rb
@@ -8,8 +8,6 @@ module AppMap
   module Handler
     module Rails
 
-      TEMPLATE_RENDER_VALUE = 'appmap.handler.rails.template.return_value'
-
       module RequestHandler
         class HTTPServerRequest < AppMap::Event::MethodEvent
           attr_accessor :normalized_path_info, :request_method, :path_info, :params, :headers
@@ -77,7 +75,7 @@ module AppMap
               event ||= HTTPServerResponse.new
               event.status = response.status
               event.headers = response.headers.dup
-              AppMap::Event::MethodReturn.build_from_invocation parent_id, return_value, nil, elapsed: elapsed, event: event
+              AppMap::Event::MethodReturn.build_from_invocation parent_id, return_value, nil, elapsed: elapsed, event: event, parameter_schema: true
             end
           end
 

--- a/lib/appmap/handler/rails/request_handler.rb
+++ b/lib/appmap/handler/rails/request_handler.rb
@@ -47,7 +47,7 @@ module AppMap
                     value: self.class.display_string(val),
                     object_id: val.__id__,
                   }.tap do |message|
-                    AppMap::Event::MethodEvent.add_schema message, val, always: true
+                    AppMap::Event::MethodEvent.add_schema message, val
                   end
                 end
               end

--- a/lib/appmap/handler/rails/sql_handler.rb
+++ b/lib/appmap/handler/rails/sql_handler.rb
@@ -44,7 +44,7 @@ module AppMap
               return unless (examiner = build_examiner)
 
               if AppMap.explain_queries? && examiner.in_transaction? && examiner.database_type == :postgres
-                unless sql =~ /\A(SAVEPOINT|RELEASE|ROLLBACK|BEGIN|INSERT|COMMIT)/i
+                if sql =~ /\A(SELECT|INSERT|DELETE|UPDATE|WITH)/i
                   examiner.execute_query 'SAVEPOINT appmap_sql_examiner'
                   begin
                     plan = examiner.execute_query(%(EXPLAIN #{sql}))
@@ -116,7 +116,7 @@ module AppMap
             end
 
             def execute_query(sql)
-              ActiveRecord::Base.connection.execute(sql).each_with_object([]) { |r, memo| memo << r }
+              ActiveRecord::Base.connection.execute(sql).to_a
             end
           end
         end

--- a/lib/appmap/handler/rails/sql_handler.rb
+++ b/lib/appmap/handler/rails/sql_handler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'appmap/event'
+require 'appmap/hook/method'
 
 module AppMap
   module Handler
@@ -21,6 +22,7 @@ module AppMap
                 sql: payload[:sql],
                 database_type: payload[:database_type]
               }.tap do |sql_query|
+                sql_query[:query_plan] = payload[:query_plan] if payload[:query_plan]
                 %i[server_version].each do |attribute|
                   sql_query[attribute] = payload[attribute] if payload[attribute]
                 end
@@ -44,15 +46,30 @@ module AppMap
               return unless (examiner = build_examiner)
 
               if AppMap.explain_queries? && examiner.in_transaction? && examiner.database_type == :postgres
-                if sql =~ /\A(SELECT|INSERT|DELETE|UPDATE|WITH)/i
-                  examiner.execute_query 'SAVEPOINT appmap_sql_examiner'
-                  begin
-                    plan = examiner.execute_query(%(EXPLAIN #{sql}))
-                    payload[:query_plan] = plan.map { |line| line[:'QUERY PLAN'] }.join("\n")
-                    examiner.execute_query 'RELEASE SAVEPOINT appmap_sql_examiner'
-                  rescue
-                    warn "Exception occurred explaining query: #{$!}"
-                    examiner.execute_query 'ROLLBACK TO SAVEPOINT appmap_sql_examiner'
+                if sql =~ /\A(SELECT|INSERT|UPDATE|DELETE|WITH)/i
+                  savepoint_established = \
+                    begin
+                      examiner.execute_query 'SAVEPOINT appmap_sql_examiner'
+                      true
+                    rescue
+                      # Probably: Sequel::DatabaseError: PG::InFailedSqlTransaction
+                      byebug
+                      warn $!
+                      false
+                    end
+
+                  if savepoint_established
+                    plan = nil
+                    begin
+                      plan = examiner.execute_query(%(EXPLAIN #{sql}))
+                    rescue
+                      warn "Exception occurred explaining query: #{$!}"
+                      examiner.execute_query 'ROLLBACK TO SAVEPOINT appmap_sql_examiner'
+                    end
+                    if plan
+                      payload[:query_plan] = plan.map { |line| line[:'QUERY PLAN'] }.join("\n")
+                      examiner.execute_query 'RELEASE SAVEPOINT appmap_sql_examiner'
+                    end
                   end
                 end
               end
@@ -123,6 +140,8 @@ module AppMap
 
         def call(_, started, finished, _, payload) # (name, started, finished, unique_id, payload)
           return if AppMap.tracing.empty?
+
+          return if Thread.current[AppMap::Hook::Method::HOOK_DISABLE_KEY] == true
 
           reentry_key = "#{self.class.name}#call"
           return if Thread.current[reentry_key] == true

--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -24,7 +24,6 @@ module AppMap
       attr_reader :hook_package, :hook_class, :hook_method, :parameters, :arity
 
       HOOK_DISABLE_KEY = 'AppMap::Hook.disable'
-      private_constant :HOOK_DISABLE_KEY
 
       def initialize(hook_package, hook_class, hook_method)
         @hook_package = hook_package

--- a/spec/handler/eval_spec.rb
+++ b/spec/handler/eval_spec.rb
@@ -32,7 +32,7 @@ describe 'AppMap::Handler::Eval' do
     expect(events[0]).to match hash_including \
       defined_class: 'Kernel',
       method_id: 'eval',
-      parameters: [{ class: 'Array', kind: :rest, name: 'arg', value: '[12]' }]
+      parameters: [{ class: 'Array', kind: :rest, name: 'arg', size: 1, value: '[12]' }]
   end
 
   # a la Ruby 2.6.3 ruby-token.rb

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -491,6 +491,7 @@ describe 'AppMap class Hooking' do
         :class: Array
         :value: "[4, 5]"
         :kind: :rest
+        :size: 2
       - :name: :kw1
         :class: String
         :value: one
@@ -503,6 +504,7 @@ describe 'AppMap class Hooking' do
         :class: Hash
         :value: "{:kw3=>:three}"
         :kind: :keyrest
+        :size: 1
       :receiver:
         :class: InstanceMethod
         :value: Instance Method fixture
@@ -1139,6 +1141,7 @@ describe 'AppMap class Hooking' do
         :class: Array
         :value: "[foo]"
         :kind: :rest
+        :size: 1
       - :name: :kw1
         :class: String
         :value: kw1
@@ -1151,6 +1154,7 @@ describe 'AppMap class Hooking' do
         :class: Hash
         :value: "{}"
         :kind: :keyrest
+        :size: 0
       :receiver:
         :class: ReportParameters
         :value: ReportParameters
@@ -1160,6 +1164,7 @@ describe 'AppMap class Hooking' do
       :return_value:
         :class: Array
         :value: "[[:rest, :args], [:keyreq, :kw1], [:key, :kw2], [:keyrest, :kws]]"
+        :size: 4
     YAML
     parameters = [[:rest, :args], [:keyreq, :kw1], [:key, :kw2], [:keyrest, :kws]]
     test_hook_behavior 'spec/fixtures/hook/report_parameters.rb', events do

--- a/spec/rails_recording_spec.rb
+++ b/spec/rails_recording_spec.rb
@@ -54,7 +54,8 @@ describe 'Rails' do
                 'http_server_response' => hash_including(
                   'status_code' => 201,
                   'headers' => hash_including('Content-Type' => 'application/json; charset=utf-8'),
-                )
+                ),
+                'return_value' => hash_including('class' => 'User', 'object_id' => Integer, 'properties' => include({'name' => 'login', 'class' => 'String'})),
               )
             )
           end

--- a/spec/rails_recording_spec.rb
+++ b/spec/rails_recording_spec.rb
@@ -55,7 +55,7 @@ describe 'Rails' do
                   'status_code' => 201,
                   'headers' => hash_including('Content-Type' => 'application/json; charset=utf-8'),
                 ),
-                'return_value' => hash_including('class' => 'User', 'object_id' => Integer, 'properties' => include({'name' => 'login', 'class' => 'String'})),
+                'return_value' => hash_including('class' => 'Hash', 'object_id' => Integer, 'properties' => include({'name' => 'login', 'class' => 'String'})),
               )
             )
           end

--- a/spec/rails_recording_spec.rb
+++ b/spec/rails_recording_spec.rb
@@ -73,6 +73,7 @@ describe 'Rails' do
                 'name' => 'params',
                 'class' => 'ActiveSupport::HashWithIndifferentAccess',
                 'object_id' => Integer,
+                'size' => 1,
                 'value' => '{login=>alice}',
                 'kind' => 'req'
               ),

--- a/test/expectations/openssl_test_key_sign2-3.1.json
+++ b/test/expectations/openssl_test_key_sign2-3.1.json
@@ -26,7 +26,8 @@
         "name": "arg",
         "class": "Array",
         "value": "[e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, the document]",
-        "kind": "rest"
+        "kind": "rest",
+        "size": 2
       }
     ],
     "receiver": {


### PR DESCRIPTION
Implement https://github.com/applandinc/appmap/pull/29

1) Hook template rendering so that we can grab the `:json` argument
2) Always emit the parameter schema of an HTTP server response; optionally emit it when enabled by APPMAP_PARAMETER_SCHEMA
3) Emit `size` of Array and Hash objects
4) Emit query `EXPLAIN` plan when enabled by APPMAP_EXPLAIN_QUERIES
