### PR TITLE
fix: Only warn if Hook::LOG is true

### DIFF
--- a/lib/appmap/hook/method.rb
+++ b/lib/appmap/hook/method.rb
@@ -75,7 +75,7 @@ module AppMap
 
         return cls if cls
 
-        warn "#{hook_method.name} not found on #{hook_class}"
+        warn "#{hook_method.name} not found on #{hook_class}" if Hook::LOG
       end
 
       def gettime


### PR DESCRIPTION
Only show this message if `Hook::LOG` is true.

Previously, this message appeared in the Travis job. e.g. https://app.travis-ci.com/github/applandinc/appmap-ruby/jobs/569606383#L885 . Examining the build log for this PR will show that it no longer appears.