### PR TITLE
fix: Eval handler now works correctly even when not tracing

### DIFF
--- a/spec/handler/class_with_eval.rb
+++ b/spec/handler/class_with_eval.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/EvalWithLocation
+
+module AppMap
+  class SpecClasses
+    class WithEval
+      eval %(def text; 'text'; end)
+    end
+  end
+end
+
+# rubocop:enable Style/EvalWithLocation

--- a/spec/handler/eval_spec.rb
+++ b/spec/handler/eval_spec.rb
@@ -57,6 +57,11 @@ describe 'AppMap::Handler::Eval' do
     end
     expect(new_cls.const_get(class_name)).to eq(cls)
   end
+
+  it 'works correctly when loaded even when not tracing' do
+    load "#{__dir__}/class_with_eval.rb"
+    expect { AppMap::SpecClasses::WithEval.new.text }.to_not raise_error(NameError)
+  end
 end
 
 module ClassMaker
@@ -64,3 +69,5 @@ module ClassMaker
     eval "class #{class_name}; end; #{class_name}"
   end
 end
+
+# rubocop:enable Security/Eval, Style/EvalWithLocation


### PR DESCRIPTION
Eval handler relies on specific call stack layout when recovering
original eval call context. Since call hook handler used to
short-circuit over trace_call method when not tracing, the layout
was unexpected when the handlers were loaded but tracing disabled
(eg. when initial code load is performed dynamically after loading
appmap gem).

The fix is to always call trace_call and short-circuit in there,
keeping the call stack the same.

Alternative, rejected solutions:
- check for tracing being disabled in eval handler and use the
  correct (shallower) call stack depth in this case,
- examine all frames sequentially in the eval handler until the
  correct one is found.

Fixes #254 