### PR TITLE
Adding link to main docs site for version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 SHA, labels, etc). It's more granular than a performance profile, but it's less
 granular than a full debug trace. It's designed to be optimal for understanding the design intent and structure of code and key data flows.
 
-# Usage
+# Usage and Requirements
 
-Visit the [AppMap for Ruby](https://appland.com/docs/reference/appmap-ruby.html) reference page on AppLand.com for a complete reference guide.
+Visit the [AppMap for Ruby](https://appland.com/docs/reference/appmap-ruby.html) reference page on AppLand.com for a complete reference guide and information on supported Ruby and Rails versions.
 
 # Development
 [![Build Status](https://travis-ci.com/applandinc/appmap-ruby.svg?branch=master)](https://travis-ci.com/applandinc/appmap-ruby)


### PR DESCRIPTION
Linking to the docs site to avoid duplication between GitHub and the main docs site.