### PR TITLE
fix: Exclude AppMaps from the gem when packaging

### DIFF
--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = `git ls-files --no-deleted`.split("
-")
+").grep_v(/appmap\.json$/)
+
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 


### PR DESCRIPTION
If there are AppMaps in the gem, the VS Code extension's Install Guide sees them and thinks recordings have been made.