### PR TITLE
fix: Remove spec and test from the gem

### DIFF
--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = `git ls-files --no-deleted`.split("
-").grep_v(/appmap\.json$/)
+").grep_v(/appmap\.json$/).grep_v(/^spec\//).grep_v(/^test\//)
 
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Fixes Windows install error:

```
Installing appmap 0.83.4 with native extensions
--- ERROR REPORT TEMPLATE -------------------------------------------------------

Errno::EACCES: Permission denied @ rb_file_s_symlink - (../../database.yml, C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/appmap-0.83.4/spec/fixtures/rails5_users_app/config/database.yml)
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:447:in `symlink'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:447:in `block (2 levels) in extract_tar_gz'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package/tar_reader.rb:65:in `each'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:413:in `block in extract_tar_gz'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:525:in `block in open_tar_gz'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:522:in `wrap'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:522:in `open_tar_gz'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:412:in `extract_tar_gz'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:392:in `block (2 levels) in extract_files'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package/tar_reader.rb:65:in `each'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:389:in `block in extract_files'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package/file_source.rb:29:in `open'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package/file_source.rb:29:in `with_read_io'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:386:in `extract_files'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/installer.rb:860:in `extract_files'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/rubygems_gem_installer.rb:26:in `install'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/source/rubygems.rb:207:in `install'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/gem_installer.rb:54:in `install'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/parallel_installer.rb:186:in `do_install'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/worker.rb:62:in `apply_func'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/worker.rb:57:in `block in process_queue'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/worker.rb:54:in `loop'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/worker.rb:54:in `process_queue'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/worker.rb:91:in `block (2 levels) in create_threads'
Errno::EACCES: Permission denied @ rb_file_s_symlink - (../../database.yml, C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/appmap-0.83.4/spec/fixtures/rails5_users_app/config/database.yml)
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:447:in `symlink'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:447:in `block (2 levels) in extract_tar_gz'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package/tar_reader.rb:65:in `each'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:413:in `block in extract_tar_gz'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:525:in `block in open_tar_gz'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:522:in `wrap'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:522:in `open_tar_gz'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:412:in `extract_tar_gz'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:392:in `block (2 levels) in extract_files'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package/tar_reader.rb:65:in `each'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:389:in `block in extract_files'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package/file_source.rb:29:in `open'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package/file_source.rb:29:in `with_read_io'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/package.rb:386:in `extract_files'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/rubygems/installer.rb:860:in `extract_files'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/rubygems_gem_installer.rb:26:in `install'
  C:/Ruby31-x64/lib/ruby/site_ruby/3.1.0/bundler/source/rubygems.rb:207:in `instal","appmap.cli.exception":"Error: An error occurred while running the command: bundle install
```