### PR TITLE
fix: Catch an uncaught EINVAL on Windows when fetching method comments

### DIFF
--- a/lib/appmap/trace.rb
+++ b/lib/appmap/trace.rb
@@ -22,7 +22,7 @@ module AppMap
 
       def comment
         @method.comment
-      rescue MethodSource::SourceNotFoundError
+      rescue MethodSource::SourceNotFoundError, Errno::EINVAL
         nil
       end
 

--- a/spec/ruby_method_spec.rb
+++ b/spec/ruby_method_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe AppMap::Trace::RubyMethod do
+  # These tests are mostly targeted towards Windows. Make sure no operating system errors go unhandled.
+  describe :comment do
+    # These methods use native implementations, and their source code files are not regular file paths.
+    let(:methods) { [''.method(:unpack1), Kernel.instance_method(:eval)] }
+
+    it 'properly handles invalid source file paths' do
+      methods.each do |method|
+        ruby_method = AppMap::Trace::RubyMethod.new(nil, nil, method, false)
+        expect { ruby_method.comment }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `method_source` gem will happily take a source path such as
`<internal:pack>:243` and [attempt to open it as a file](https://github.com/banister/method_source/blob/master/lib/method_source.rb#L53). In this case, Windows will raise an EINVAL error which is not caught by the gem and the error will propagate through the agent and fail a pending recording.

This did not seem to affect any other platform.