### PR TITLE
feat: Tune method parameters

### DIFF
--- a/lib/appmap/builtin_hooks/activesupport.yml
+++ b/lib/appmap/builtin_hooks/activesupport.yml
@@ -11,7 +11,9 @@
   require_name: active_support/security_utils
   force: true
 - method: ActiveSupport.run_load_hooks
-  label: deserialize.safe
+  labels:
+  - deserialize.safe
+  - lang.eval.safe
   require_name: active_support/lazy_load_hooks
   force: true
 - method: ActiveSupport::MessageEncryptor#encrypt_and_sign

--- a/lib/appmap/builtin_hooks/ruby.yml
+++ b/lib/appmap/builtin_hooks/ruby.yml
@@ -2,6 +2,7 @@
   - Marshal#load
   - Marshal#restore
   require_name: ruby
+  handler_class: AppMap::Handler::MarshalLoadHandler
   label: deserialize.unsafe
 - method: Marshal#dump
   require_name: ruby
@@ -29,3 +30,6 @@
   - Process#spawn
   require_name: ruby
   label: system.exec
+- methods:
+  - ERB#result
+  require_name: ruby

--- a/lib/appmap/event.rb
+++ b/lib/appmap/event.rb
@@ -193,7 +193,7 @@ module AppMap
 
         public
 
-        def build_from_invocation(defined_class, method, receiver, arguments, event: MethodCall.new)
+        def build_from_invocation(defined_class, method, receiver, arguments, parameters: method.parameters, event: MethodCall.new)
           event ||= MethodCall.new
           defined_class ||= 'Class'
 
@@ -208,10 +208,10 @@ module AppMap
 
             # Check if the method has key parameters. If there are any they'll always be last.
             # If yes, then extract it from arguments.
-            has_key = [[:dummy], *method.parameters].last.first.to_s.start_with?('key') && arguments[-1].is_a?(Hash)
+            has_key = [[:dummy], *parameters].last.first.to_s.start_with?('key') && arguments[-1].is_a?(Hash)
             kwargs = has_key && arguments[-1].dup || {}
 
-            event.parameters = method.parameters.map.with_index do |method_param, idx|
+            event.parameters = parameters.map.with_index do |method_param, idx|
               param_type, param_name = method_param
               param_name ||= 'arg'
               value = case param_type

--- a/lib/appmap/handler/marshal_load_handler.rb
+++ b/lib/appmap/handler/marshal_load_handler.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'appmap/handler/function_handler'
+
+module AppMap
+  module Handler
+    class MarshalLoadHandler < FunctionHandler
+      PARAMETERS= [
+        [ :req, :source ],
+        [ :rest ],
+      ]
+
+      def handle_call(receiver, args)
+        AppMap::Event::MethodCall.build_from_invocation(defined_class, hook_method, receiver, args, parameters: PARAMETERS)
+      end
+    end
+  end
+end

--- a/spec/handler/eval_handler_spec.rb
+++ b/spec/handler/eval_handler_spec.rb
@@ -32,7 +32,10 @@ describe 'AppMap::Handler::EvalHandler' do
     expect(events[0]).to match hash_including \
       defined_class: 'Kernel',
       method_id: 'eval',
-      parameters: [{ class: 'Array', kind: :rest, name: 'arg', size: 1, value: '[12]' }]
+      parameters: [
+        { class: 'String', kind: :req,  name: :string, value: '12' },
+        { class: 'Array',  kind: :rest, name: 'arg', size: 0, value: '[]' },
+      ]
   end
 
   # a la Ruby 2.6.3 ruby-token.rb


### PR DESCRIPTION
Parameters for `Kernel#eval` and `Marshal#load` are overridden to present the first param as the string to eval/load, rather than presenting all params as a single Array (`:rest`).
