### PR TITLE
fix: Make Rack a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
+
+gem 'rack', '~> 2'

--- a/appmap.gemspec
+++ b/appmap.gemspec
@@ -28,10 +28,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'method_source'
-  spec.add_dependency 'rack'
   spec.add_dependency 'reverse_markdown'
 
   spec.add_runtime_dependency 'activesupport'
+  spec.add_runtime_dependency 'rack'
 
   spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'minitest', '~> 5.15'
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rdoc'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency "rake-compiler"
+  spec.add_development_dependency 'rake-compiler'
 
   # Testing
   spec.add_development_dependency 'climate_control'


### PR DESCRIPTION
Pin Rack to version 2 for testing purposes