### PR TITLE
fix: Faster comment extraction

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Layout/LineLength:
   Max: 120
 
 Metrics/BlockLength:
-  ExcludedMethods:
+  AllowedMethods:
   - describe
   - it
   - context


### PR DESCRIPTION
AppMap needs to extract method comments to apply labels. This change makes this process faster.

Note this is roughly the same change as in #279 but (IMO) a bit cleaner, plus it avoids reading the whole file by using IO#lines iterator and only taking the required number of lines. As such it fixes #276 (in a way).