### PR TITLE
feat: Emit metadata.recorder.type

### DIFF
--- a/lib/appmap/cucumber.rb
+++ b/lib/appmap/cucumber.rb
@@ -92,7 +92,8 @@ module AppMap
             'version' => Gem.loaded_specs['cucumber']&.version&.to_s
           }
           m['recorder'] = {
-            'name' => 'cucumber'
+            'name' => 'cucumber',
+            'type' => 'tests'
           }
         end
       end

--- a/lib/appmap/middleware/remote_recording.rb
+++ b/lib/appmap/middleware/remote_recording.rb
@@ -63,7 +63,8 @@ module AppMap
 
         metadata = AppMap.detect_metadata
         metadata[:recorder] = {
-          name: 'remote_recording'
+          name: 'remote_recording',
+          type: 'remote'
         }
 
         response = JSON.generate \
@@ -103,7 +104,8 @@ module AppMap
             metadata[:name] = appmap_name
             metadata[:timestamp] = start_time.to_f
             metadata[:recorder] = {
-              name: 'record_requests'
+              name: 'rack',
+              type: 'requests'
             }
     
             appmap = {

--- a/lib/appmap/minitest.rb
+++ b/lib/appmap/minitest.rb
@@ -101,7 +101,8 @@ module AppMap
             version: Gem.loaded_specs['minitest']&.version&.to_s
           }
           m[:recorder] = {
-            name: 'minitest'
+            name: 'minitest',
+            type: 'tests'
           }
           m[:test_status] = test_status
           if exception

--- a/lib/appmap/record.rb
+++ b/lib/appmap/record.rb
@@ -14,7 +14,8 @@ at_exit do
 
   metadata = AppMap.detect_metadata
   metadata[:recorder] = {
-    name: 'record_process'
+    name: 'record_process',
+    type: 'process'
   }
 
   appmap = {

--- a/lib/appmap/rspec.rb
+++ b/lib/appmap/rspec.rb
@@ -192,7 +192,8 @@ module AppMap
             version: Gem.loaded_specs['rspec-core']&.version&.to_s
           }
           m[:recorder] = {
-            name: 'rspec'
+            name: 'rspec',
+            type: 'tests'
           }
           m[:test_status] = test_status
           if exception

--- a/lib/appmap/version.rb
+++ b/lib/appmap/version.rb
@@ -5,7 +5,7 @@ module AppMap
 
   VERSION = '0.90.1'
 
-  APPMAP_FORMAT_VERSION = '1.7.0'
+  APPMAP_FORMAT_VERSION = '1.9.0'
 
   SUPPORTED_RUBY_VERSIONS = %w[2.5 2.6 2.7 3.0 3.1].freeze
 

--- a/test/cucumber_test.rb
+++ b/test/cucumber_test.rb
@@ -35,7 +35,7 @@ class CucumberTest < Minitest::Test
       assert_includes metadata.keys, 'client'
       assert_equal({ name: 'appmap', url: AppMap::URL, version: AppMap::VERSION }.stringify_keys, metadata['client'])
       assert_includes metadata.keys, 'recorder'
-      assert_equal({ name: 'cucumber' }.stringify_keys, metadata['recorder'])
+      assert_equal({ name: 'cucumber', type: 'tests' }.stringify_keys, metadata['recorder'])
 
       assert_includes metadata.keys, 'frameworks'
       cucumber = metadata['frameworks'].select {|f| f['name'] == 'cucumber'}
@@ -62,7 +62,7 @@ class CucumberTest < Minitest::Test
       assert_includes metadata.keys, 'client'
       assert_equal({ name: 'appmap', url: AppMap::URL, version: AppMap::VERSION }.stringify_keys, metadata['client'])
       assert_includes metadata.keys, 'recorder'
-      assert_equal({ name: 'cucumber' }.stringify_keys, metadata['recorder'])
+      assert_equal({ name: 'cucumber', type: 'tests' }.stringify_keys, metadata['recorder'])
 
       assert_includes metadata.keys, 'frameworks'
       cucumber = metadata['frameworks'].select {|f| f['name'] == 'cucumber'}

--- a/test/minitest_test.rb
+++ b/test/minitest_test.rb
@@ -29,6 +29,7 @@ class MinitestTest < Minitest::Test
       metadata = appmap['metadata']
       assert_equal 'minitest_recorder', metadata['app']
       assert_equal 'minitest', metadata['recorder']['name']
+      assert_equal 'tests', metadata['recorder']['type']
       assert_equal 'ruby', metadata['language']['name']
       assert_equal 'Hello hello', metadata['name']
       assert_equal 'test/hello_test.rb:9', metadata['source_location']

--- a/test/rspec_test.rb
+++ b/test/rspec_test.rb
@@ -32,7 +32,7 @@ class RSpecTest < Minitest::Test
       assert_includes metadata.keys, 'client'
       assert_equal({ name: 'appmap', url: AppMap::URL, version: AppMap::VERSION }.stringify_keys, metadata['client'])
       assert_includes metadata.keys, 'recorder'
-      assert_equal({ name: 'rspec' }.stringify_keys, metadata['recorder'])
+      assert_equal({ name: 'rspec', type: 'tests' }.stringify_keys, metadata['recorder'])
 
       assert_includes metadata.keys, 'frameworks'
       rspec = metadata['frameworks'].select {|f| f['name'] == 'rspec'}


### PR DESCRIPTION
Supports AppMap version 1.9.0

https://github.com/applandinc/appmap/pull/32