### PR TITLE
fix: Use require instead of require_relative to load extension

### DIFF
--- a/lib/appmap/agent.rb
+++ b/lib/appmap/agent.rb
@@ -3,13 +3,14 @@ require_relative "hook"
 require_relative "config"
 require_relative "trace"
 require_relative "class_map"
+require_relative "detect_enabled"
 require_relative "metadata"
 require_relative "util"
 require_relative "open"
 
 # load extension
-require_relative "appmap"
-require_relative "detect_enabled"
+# note this cannot be require_relative because the extension might not be in the same directory
+require "appmap/appmap"
 
 module AppMap
   class << self


### PR DESCRIPTION
This pull request includes changes to the `lib/appmap/agent.rb` file to improve the loading of required files and handle potential directory differences for the `appmap` extension.

File loading improvements:

* [`lib/appmap/agent.rb`](diffhunk://#diff-258c89b9a6a74a6adfdcef03335fb0252d8694f412c18e01b72d38b530659ff7R6-R13): Changed the `require_relative "appmap"` statement to `require "appmap/appmap"` to handle cases where the `appmap` extension might not be in the same directory.